### PR TITLE
Create .gitignore to comply with Godot Asset Library requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Godot 4+ specific ignores
+.godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json


### PR DESCRIPTION
The Asset Library application for FuncGodot has been [rejected](https://godotengine.org/asset-library/asset/edit/11253) because the repo lacks a `.gitignore`. I have added the template `.gitignore` file from the official docs. After this change the package can be resubmitted for inclusion.