### PR TITLE
Adds Automatic Building Functionality to Map Nodes

### DIFF
--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -40,9 +40,10 @@ var _map_file_internal: String = ""
 @export var block_until_complete: bool = false
 ## How many nodes to set the owner of, or add children of, at once. Higher values may lead to quicker build times, but a less responsive editor.
 @export var set_owner_batch_size: int = 1000
-## If true, automatically builds this map when the relevant map file is reimported.
+## If true, automatically triggers a build on this Node when the relevant local map file is imported.
+## An import can occur when the Resource is first added, when the resource is updated externally, or when an import is manually triggered.
 ## This means saving over the map file and tabbing into Godot will cause the map to update automatically.
-@export var auto_build: bool = true
+@export var auto_build_on_local_file_import: bool = false
 
 # Build context variables
 var func_godot: FuncGodot = null
@@ -72,7 +73,7 @@ var entity_collision_shapes: Array = []
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		EditorInterface.get_resource_filesystem().resources_reimported.connect(_on_reimport)
-		if auto_build:
+		if auto_build_on_local_file_import:
 			verify_and_build()
 	
 	if not DEBUG:
@@ -91,7 +92,7 @@ func verify_and_build() -> void:
 		emit_signal("build_failed")
 
 func _on_reimport(resources: PackedStringArray) -> void:
-	if !auto_build:
+	if !auto_build_on_local_file_import:
 		return
 	
 	for resource in resources:

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -43,7 +43,7 @@ var _map_file_internal: String = ""
 ## If true, automatically triggers a build on this Node when the relevant local map file is imported.
 ## An import can occur when the Resource is first added, when the resource is updated externally, or when an import is manually triggered.
 ## This means saving over the map file and tabbing into Godot will cause the map to update automatically.
-@export var auto_build_on_local_file_import: bool = false
+@export var auto_build_on_local_file_import: bool = true
 
 # Build context variables
 var func_godot: FuncGodot = null

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -40,10 +40,8 @@ var _map_file_internal: String = ""
 @export var block_until_complete: bool = false
 ## How many nodes to set the owner of, or add children of, at once. Higher values may lead to quicker build times, but a less responsive editor.
 @export var set_owner_batch_size: int = 1000
-## If true, automatically triggers a build on this Node when the relevant local map file is imported.
-## An import can occur when the Resource is first added, when the resource is updated externally, or when an import is manually triggered.
-## This means saving over the map file and tabbing into Godot will cause the map to update automatically.
-@export var auto_build_on_local_file_import: bool = true
+## If true, automatically rebuilds the map when the local map file is reimported after being saved externally.
+@export var auto_build_on_local_map_update: bool = true
 
 # Build context variables
 var func_godot: FuncGodot = null
@@ -73,7 +71,7 @@ var entity_collision_shapes: Array = []
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		EditorInterface.get_resource_filesystem().resources_reimported.connect(_on_reimport)
-		if auto_build_on_local_file_import:
+		if auto_build_on_local_map_update:
 			verify_and_build()
 	
 	if not DEBUG:
@@ -92,7 +90,7 @@ func verify_and_build() -> void:
 		emit_signal("build_failed")
 
 func _on_reimport(resources: PackedStringArray) -> void:
-	if !auto_build_on_local_file_import:
+	if !auto_build_on_local_map_update:
 		return
 	
 	for resource in resources:

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -44,6 +44,8 @@ var _map_file_internal: String = ""
 ## This means saving over the map file and tabbing into Godot will cause the map to update automatically.
 @export var auto_build: bool = true:
 	set(value):
+		if !Engine.is_editor_hint():
+			return
 		auto_build = value
 		if auto_build && !EditorInterface.get_resource_filesystem().resources_reimported.is_connected(_on_reimport):
 			EditorInterface.get_resource_filesystem().resources_reimported.connect(_on_reimport)


### PR DESCRIPTION
Requiring a manual press of a 'build' button after each map change to see the effects within Godot becomes tedious quickly, not to mention requiring that you manually hunt down each map Node one at a time to do so.

This PR adds an `auto_reload` property to map Nodes allowing them to react to the reimporting of a map file, making working with them very similar to working with .blend files directly.