### PR TITLE
Integrates FuncGodot with Godot's Usual Settings

### DIFF
--- a/addons/func_godot/func_godot_local_config.tres
+++ b/addons/func_godot/func_godot_local_config.tres
@@ -1,7 +1,0 @@
-[gd_resource type="Resource" script_class="FuncGodotLocalConfig" load_steps=2 format=3 uid="uid://bqjt7nyekxgog"]
-
-[ext_resource type="Script" path="res://addons/func_godot/src/util/func_godot_local_config.gd" id="1_g8kqj"]
-
-[resource]
-script = ExtResource("1_g8kqj")
-export_func_godot_settings = false

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -76,11 +76,11 @@ func _exit_tree() -> void:
 		func_godot_map_progress_bar = null
 	
 	# Cleanup Editor Settings
-	FuncGodotLocalConfig.remove_editor_settings()
+	#INFO: I realized that doing this defeats the purpose of using EditorSettings
+	# FuncGodotLocalConfig.remove_editor_settings()
 	
 	# Cleanup Project Settings
-	#INFO: I realized that doing this defeats the purpose of using EditorSettings
-	# FuncGodotProjectConfig.remove_project_settings()
+	FuncGodotProjectConfig.remove_project_settings()
 
 ## Create the toolbar controls for [FuncGodotMap] instances in the editor
 func create_func_godot_map_control() -> Control:

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -49,6 +49,7 @@ func _enter_tree() -> void:
 	
 	# Setup Editor Settings
 	FuncGodotLocalConfig.setup_editor_settings()
+	FuncGodotLocalConfig.cleanup_legacy()
 
 func _exit_tree() -> void:
 	remove_custom_type("FuncGodotMap")

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -50,6 +50,9 @@ func _enter_tree() -> void:
 	# Setup Editor Settings
 	FuncGodotLocalConfig.setup_editor_settings()
 	FuncGodotLocalConfig.cleanup_legacy()
+	
+	# Setup Project Settings
+	FuncGodotProjectConfig.setup_project_settings()
 
 func _exit_tree() -> void:
 	remove_custom_type("FuncGodotMap")
@@ -72,7 +75,11 @@ func _exit_tree() -> void:
 		func_godot_map_progress_bar.queue_free()
 		func_godot_map_progress_bar = null
 	
+	# Cleanup Editor Settings
 	FuncGodotLocalConfig.remove_editor_settings()
+	
+	# Cleanup Project Settings
+	FuncGodotProjectConfig.remove_project_settings()
 
 ## Create the toolbar controls for [FuncGodotMap] instances in the editor
 func create_func_godot_map_control() -> Control:

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -79,7 +79,8 @@ func _exit_tree() -> void:
 	FuncGodotLocalConfig.remove_editor_settings()
 	
 	# Cleanup Project Settings
-	FuncGodotProjectConfig.remove_project_settings()
+	#INFO: I realized that doing this defeats the purpose of using EditorSettings
+	# FuncGodotProjectConfig.remove_project_settings()
 
 ## Create the toolbar controls for [FuncGodotMap] instances in the editor
 func create_func_godot_map_control() -> Control:

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -46,6 +46,9 @@ func _enter_tree() -> void:
 	add_control_to_container(EditorPlugin.CONTAINER_INSPECTOR_BOTTOM, func_godot_map_progress_bar)
 	
 	add_custom_type("FuncGodotMap", "Node3D", preload("res://addons/func_godot/src/map/func_godot_map.gd"), null)
+	
+	# Setup Editor Settings
+	FuncGodotLocalConfig.setup_editor_settings()
 
 func _exit_tree() -> void:
 	remove_custom_type("FuncGodotMap")
@@ -67,6 +70,8 @@ func _exit_tree() -> void:
 		remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, func_godot_map_progress_bar)
 		func_godot_map_progress_bar.queue_free()
 		func_godot_map_progress_bar = null
+	
+	FuncGodotLocalConfig.remove_editor_settings()
 
 ## Create the toolbar controls for [FuncGodotMap] instances in the editor
 func create_func_godot_map_control() -> Control:

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -31,7 +31,7 @@ signal unwrap_uv2_complete()
 var _map_file_internal: String = ""
 
 ## Map settings resource that defines map build scale, textures location, and more.
-@export var map_settings: FuncGodotMapSettings = load("res://addons/func_godot/func_godot_default_map_settings.tres")
+@export var map_settings: FuncGodotMapSettings = FuncGodotProjectConfig.get_setting(FuncGodotProjectConfig.PROPERTY.DEFAULT_MAP_CONFIG)
 
 @export_category("Build")
 ## If true, print profiling data before and after each build step.

--- a/addons/func_godot/src/util/func_godot_project_config.gd
+++ b/addons/func_godot/src/util/func_godot_project_config.gd
@@ -1,0 +1,56 @@
+@tool
+@icon("res://addons/func_godot/icons/icon_godot_ranger.svg")
+## Local machine map editor settings. Can define global defaults for some FuncGodot properties.
+class_name FuncGodotProjectConfig
+
+const DEFAULT_SETTINGS_PATH := "res://addons/func_godot/func_godot_default_map_settings.tres"
+
+enum PROPERTY {
+	DEFAULT_MAP_CONFIG,
+}
+
+const BASE_PATH := "func_godot/maps/"
+
+static var CONFIG_PROPERTIES := {
+	PROPERTY.DEFAULT_MAP_CONFIG: {
+		"usage": PROPERTY_USAGE_EDITOR,
+		"default": load(DEFAULT_SETTINGS_PATH).duplicate(),
+		"type": TYPE_OBJECT,
+		"hint": PROPERTY_HINT_RESOURCE_TYPE,
+		"hint_string": "FuncGodotMapSettings",
+		"basic": true,
+	},
+}
+
+static func get_setting(property: PROPERTY):
+	return ProjectSettings.get_setting_with_override(_get_path(property))
+
+static func set_setting(property: PROPERTY, value):
+	ProjectSettings.set_setting(BASE_PATH + str(property).to_lower(), value)
+
+static func setup_project_settings():
+	for property in CONFIG_PROPERTIES.keys():
+		var name := _get_path(property)
+		
+		if ProjectSettings.has_setting(name):
+			continue
+		
+		var config: Dictionary = CONFIG_PROPERTIES[property]
+		
+		ProjectSettings.set_setting(name, config["default"])
+		ProjectSettings.set_initial_value(name, config["default"])
+		
+		var hint := config.duplicate()
+		hint["name"] = name
+		ProjectSettings.add_property_info(hint)
+		
+		ProjectSettings.set_as_basic(name, config["basic"])
+
+static func remove_project_settings():
+	for property in CONFIG_PROPERTIES.keys():
+		print("REMOVING: " + _get_path(property))
+		ProjectSettings.set_setting(_get_path(property), null)
+
+static func _get_path(property: PROPERTY) -> String:
+	print("GETTING PATH: " + BASE_PATH + PROPERTY.keys()[property].to_lower())
+	return BASE_PATH + PROPERTY.keys()[property].to_lower()

--- a/addons/func_godot/src/util/func_godot_project_config.gd
+++ b/addons/func_godot/src/util/func_godot_project_config.gd
@@ -29,7 +29,7 @@ static func set_setting(property: PROPERTY, value):
 	ProjectSettings.set_setting(BASE_PATH + str(property).to_lower(), value)
 
 static func setup_project_settings():
-	for property in CONFIG_PROPERTIES.keys():
+	for property in CONFIG_PROPERTIES:
 		var name := _get_path(property)
 		
 		if ProjectSettings.has_setting(name):
@@ -48,9 +48,7 @@ static func setup_project_settings():
 
 static func remove_project_settings():
 	for property in CONFIG_PROPERTIES.keys():
-		print("REMOVING: " + _get_path(property))
 		ProjectSettings.set_setting(_get_path(property), null)
 
 static func _get_path(property: PROPERTY) -> String:
-	print("GETTING PATH: " + BASE_PATH + PROPERTY.keys()[property].to_lower())
 	return BASE_PATH + PROPERTY.keys()[property].to_lower()


### PR DESCRIPTION
This pr switches FuncGodot's local and project-wide settings to use Godot's Editor and Project Settings respectively.

Accessing local configuration options via a 'Resource' within the Plugin's directory that only exists once and is never actually modified while the real information is saved to a JSON file within the game's app data directory is- although quite an interesting solution- not really ideal. Anything used to configure how the plugin operates with the individual game or project can be exposed to the user in ProjectSettings, and anything used to configure the interaction of the plugin with the user's local machine can be done with EditorSettings, both of which can be set up by the plugin when enabled. 
This eliminates the need for the user to re-specify the location of their editor for each project, the duplicated saving of the same information, and means that the user doesn't need to access an arbitrary file hidden somewhere in the plugin directory.

This pr isn't fully finished as ideally it would *also* move per-editor configuration such as the TrenchBroom file into EditorSettings, but I'm making it as a draft now to open discussion to these changes and what others think of them. My piece would be that placing configuration files of any kind, be it default map Resources, local config, etc., into the Plugins directory is sub-optimal and should be avoided, while utilizing the configuration system Godot *already* has in place makes the addon more intuitive, easier to operate, more compatible with external tools and knowledge, and overall feel more 'first party' and cleanly integrated with the Editor.