### PR TITLE
Implement support for ORMMaterial3D

### DIFF
--- a/addons/func_godot/src/map/func_godot_map_settings.gd
+++ b/addons/func_godot/src/map/func_godot_map_settings.gd
@@ -56,6 +56,8 @@ extends Resource
 @export var ao_map_pattern: String = "%s_ao.%s"
 ## Automatic PBR material generation height map pattern
 @export var height_map_pattern: String = "%s_height.%s"
+## Automatic PBR material generation ORM map pattern
+@export var orm_map_pattern: String = "%s_orm.%s"
 
 ## If true, all materials will be unshaded, ignoring light. Also known as "fullbright".
 @export var unshaded: bool = false

--- a/addons/func_godot/src/util/func_godot_texture_loader.gd
+++ b/addons/func_godot/src/util/func_godot_texture_loader.gd
@@ -7,7 +7,8 @@ enum PBRSuffix {
 	ROUGHNESS,
 	EMISSION,
 	AO,
-	HEIGHT
+	HEIGHT,
+	ORM
 }
 
 # Suffix string / Godot enum / StandardMaterial3D property
@@ -19,6 +20,7 @@ const PBR_SUFFIX_NAMES: Dictionary = {
 	PBRSuffix.EMISSION: 'emission',
 	PBRSuffix.AO: 'ao',
 	PBRSuffix.HEIGHT: 'height',
+	PBRSuffix.ORM: 'orm'
 }
 
 const PBR_SUFFIX_PATTERNS: Dictionary = {
@@ -28,7 +30,8 @@ const PBR_SUFFIX_PATTERNS: Dictionary = {
 	PBRSuffix.ROUGHNESS: '%s_roughness.%s',
 	PBRSuffix.EMISSION: '%s_emission.%s',
 	PBRSuffix.AO: '%s_ao.%s',
-	PBRSuffix.HEIGHT: '%s_height.%s'
+	PBRSuffix.HEIGHT: '%s_height.%s',
+	PBRSuffix.ORM: '%s_orm.%s'
 }
 
 var PBR_SUFFIX_TEXTURES: Dictionary = {
@@ -38,7 +41,8 @@ var PBR_SUFFIX_TEXTURES: Dictionary = {
 	PBRSuffix.ROUGHNESS: StandardMaterial3D.TEXTURE_ROUGHNESS,
 	PBRSuffix.EMISSION: StandardMaterial3D.TEXTURE_EMISSION,
 	PBRSuffix.AO: StandardMaterial3D.TEXTURE_AMBIENT_OCCLUSION,
-	PBRSuffix.HEIGHT: StandardMaterial3D.TEXTURE_HEIGHTMAP
+	PBRSuffix.HEIGHT: StandardMaterial3D.TEXTURE_HEIGHTMAP,
+	PBRSuffix.ORM: ORMMaterial3D.TEXTURE_ORM
 }
 
 const PBR_SUFFIX_PROPERTIES: Dictionary = {
@@ -121,6 +125,8 @@ func create_material(texture_name: String) -> Material:
 		material.set_texture(StandardMaterial3D.TEXTURE_ALBEDO, texture)
 	elif material is ShaderMaterial && map_settings.default_material_albedo_uniform != "":
 		material.set_shader_parameter(map_settings.default_material_albedo_uniform, texture)
+	elif material is ORMMaterial3D:
+		material.set_texture(ORMMaterial3D.TEXTURE_ALBEDO, texture)
 	
 	var pbr_textures : Dictionary = get_pbr_textures(texture_name)
 	


### PR DESCRIPTION
Allows you to assign an ORMMaterial3D as the default material to use ORM maps in place of standalone AO, metallic and roughness maps.