### PR TITLE
Fix outdated build_def_text() signature on ModelPointClass

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
@@ -32,7 +32,7 @@ enum TargetMapEditor {
 		file.store_string('')
 		file.close()
 
-func build_def_text(model_key_supported: bool = true) -> String:
+func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM) -> String:
 	_generate_model()
 	return super()
 


### PR DESCRIPTION
Fixes an issue where Godot would not allow ModelPointClass or PointClass resources to be loaded into the project.

When the build_def_text() function was updated to prefer an enum of editors instead of a bool, this wasn't updated in ModelPointClass, which uses `super()`, which prevented PointClass from loading as well. This prevented any PointClass resources or any classes extending it from being added to new projects using Godot 4.2.2 stable and this latest github repository.

## Previous Behaviour
> Failed to load script "res://addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd" with error "Parse Error". (User)
> Cannot get class 'FuncGodotFGDPointClass'. editor/create_dialog.cpp:271 - Condition "inherits.is_empty()" is true.

New PointClass resources were not available in the resource list, new ModelPointClass resources were cancelled before giving the user the dialog box to name their new resource.

## New Behaviour
PointClass and ModelPointClass resources can be created in the project, saved, and re-opened.