### PR TITLE
Added Nearest/Linear Filtering Option for Materials Generated

### DIFF
--- a/addons/func_godot/src/map/func_godot_map_settings.gd
+++ b/addons/func_godot/src/map/func_godot_map_settings.gd
@@ -62,6 +62,9 @@ extends Resource
 ## If true, all materials will be unshaded, ignoring light. Also known as "fullbright".
 @export var unshaded: bool = false
 
+## If true, all materials will use Nearest sampling, if false materials will use Linear
+@export var nearest_filtering: bool = true
+
 ## Save automatically generated materials to disk, allowing reuse across [FuncGodotMap] nodes. [i]NOTE: Materials do not use the Default Material settings after saving.[/i]
 @export var save_generated_materials: bool = true
 

--- a/addons/func_godot/src/util/func_godot_texture_loader.gd
+++ b/addons/func_godot/src/util/func_godot_texture_loader.gd
@@ -101,6 +101,13 @@ func create_material(texture_name: String) -> Material:
 	var material_path: String = "%s/%s.%s" % [map_settings.base_texture_dir, texture_name, map_settings.material_file_extension]
 	if not material_path in material_dict and (FileAccess.file_exists(material_path) or FileAccess.file_exists(material_path + ".remap")):
 		var loaded_material: Material = load(material_path)
+
+		#Set Material Texture Sampling Filter
+		if map_settings.nearest_filtering == true:
+			loaded_material.set_texture_filter(BaseMaterial3D.TEXTURE_FILTER_NEAREST)
+		else:
+			loaded_material.set_texture_filter(BaseMaterial3D.TEXTURE_FILTER_LINEAR)
+		
 		if loaded_material:
 			material_dict[material_path] = loaded_material
 	


### PR DESCRIPTION
I updated a feature to select which type of sampling you would like the materials to be generated as.
This is useful because Quake mappers may enjoy to use Nearest, and users familiar with Gold Source may enjoy to use Linear more.

Updates:
//func_godot_map_settings
```
## If true, all materials will use Nearest sampling, if false materials will use Linear
@export var nearest_filtering: bool = true
```

```
//func_godot_texture_loader
line 100:
#Set Material Texture Sampling Filter
		if map_settings.nearest_filtering == true:
			loaded_material.set_texture_filter(BaseMaterial3D.TEXTURE_FILTER_NEAREST)
		else:
			loaded_material.set_texture_filter(BaseMaterial3D.TEXTURE_FILTER_LINEAR)

```
