### PR TITLE
Map build optimizations

### DIFF
--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -98,7 +98,7 @@ func fetch_surfaces(sg: FuncGodotSurfaceGatherer) -> Array:
 		var tangents: PackedFloat64Array
 		var uvs: PackedVector2Array
 		for v in surf.vertices:
-			vertices.append(Vector3(v.vertex.y, v.vertex.z, v.vertex.x) / map_settings.inverse_scale_factor)
+			vertices.append(Vector3(v.vertex.y, v.vertex.z, v.vertex.x) * map_settings.scale_factor)
 			normals.append(Vector3(v.normal.y, v.normal.z, v.normal.x))
 			tangents.append(v.tangent.y)
 			tangents.append(v.tangent.z)

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -272,7 +272,7 @@ func unwrap_uv2(node: Node = null) -> void:
 		if target_node.gi_mode == GeometryInstance3D.GI_MODE_STATIC:
 			var mesh: Mesh = target_node.get_mesh()
 			if mesh is ArrayMesh:
-				mesh.lightmap_unwrap(Transform3D.IDENTITY, map_settings.uv_unwrap_texel_size / map_settings.inverse_scale_factor)
+				mesh.lightmap_unwrap(Transform3D.IDENTITY, map_settings.uv_unwrap_texel_size * map_settings.scale_factor)
 	
 	for child in target_node.get_children():
 		unwrap_uv2(child)
@@ -463,13 +463,13 @@ func build_entity_nodes() -> Array:
 				push_error("Invalid vector format for \'origin\' in " + node.name)
 			if 'position' in node:
 				if node.position is Vector3:
-					node.position = origin_vec / map_settings.inverse_scale_factor
+					node.position = origin_vec * map_settings.scale_factor
 				elif node.position is Vector2:
 					node.position = Vector2(origin_vec.z, -origin_vec.y)
 		else:
 			if entity_idx != 0 and 'position' in node:
 				if node.position is Vector3:
-					node.position = entity_dict['center'] / map_settings.inverse_scale_factor
+					node.position = entity_dict['center'] * map_settings.scale_factor
 		
 		entity_nodes[entity_idx] = node
 		

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -885,9 +885,6 @@ func set_owners_complete() -> void:
 ## Apply Map File properties to [Node3D] instances, transferring Map File dictionaries to [Node3D.func_godot_properties]
 ## and then calling the appropriate callbacks.
 func apply_properties_and_finish() -> void:
-	# Array of all entities' properties
-	var properties_arr: Array[Dictionary] = []
-	
 	for entity_idx in range(0, entity_nodes.size()):
 		var entity_node: Node = entity_nodes[entity_idx] as Node
 		if not entity_node:
@@ -1011,13 +1008,10 @@ func apply_properties_and_finish() -> void:
 		if 'func_godot_properties' in entity_node:
 			entity_node.func_godot_properties = properties
 		
-		properties_arr.append(properties.duplicate(true))
-	
-	for entity_idx in range(0, entity_nodes.size()):
-		var entity_node: Node = entity_nodes[entity_idx] as Node
-		if entity_node and entity_node.has_method("_func_godot_apply_properties"):
-			entity_node._func_godot_apply_properties(properties_arr[entity_idx])
-		if entity_node and entity_node.has_method("_func_godot_build_complete"):
+		if entity_node.has_method("_func_godot_apply_properties"):
+			entity_node.call("_func_godot_apply_properties", properties)
+		
+		if entity_node.has_method("_func_godot_build_complete"):
 			entity_node.call_deferred("_func_godot_build_complete")
 
 # Cleanup after build is finished (internal)

--- a/addons/func_godot/src/map/func_godot_map_settings.gd
+++ b/addons/func_godot/src/map/func_godot_map_settings.gd
@@ -1,10 +1,15 @@
 @icon("res://addons/func_godot/icons/icon_godot_ranger.svg")
+@tool
 ## Reusable map settings configuration for [FuncGodotMap] nodes.
 class_name FuncGodotMapSettings
 extends Resource
 
 ## Ratio between map editor units and Godot units. FuncGodot will divide brush coordinates by this number when building. This does not affect entity properties unless scripted to do so.
-@export var inverse_scale_factor: float = 32.0
+var scale_factor: float = 0.03125
+@export var inverse_scale_factor: float = 32.0 :
+	set(value):
+		inverse_scale_factor = value
+		scale_factor = 1.0 / value
 
 ## [FuncGodotFGDFile] that translates map file classnames into Godot nodes and packed scenes.
 @export var entity_fgd: FuncGodotFGDFile = preload("res://addons/func_godot/fgd/func_godot_fgd.tres")


### PR DESCRIPTION
FuncGodotMapSettings now has a private property `scale_factor`, which gets updated in `inverse_scale_factor`'s new setter method. Map Settings has been turned into a tool script to facilitate this. The purpose is to replace all instances of division in the build process with multiplication, to squeeze a bit more performance out of the build.

On top of this, FuncGodotMap's `apply_properties_and_finish()` method has had an unnecessary entity loop removed and the contents of the loop moved to the remaining entity loop. An array of dictionaries was able to be removed as a result. Additionally, the direct call to `_func_godot_apply_properties()` has been replaced with a call via String, to better ensure that the correct override is called in the event of inheriting classes.