### PR TITLE
Remove Unshaded Map Setting

### DIFF
--- a/addons/func_godot/src/map/func_godot_map_settings.gd
+++ b/addons/func_godot/src/map/func_godot_map_settings.gd
@@ -67,9 +67,6 @@ var scale_factor: float = 0.03125
 ## Automatic PBR material generation ORM map pattern
 @export var orm_map_pattern: String = "%s_orm.%s"
 
-## If true, all materials will be unshaded, ignoring light. Also known as "fullbright".
-@export var unshaded: bool = false
-
 ## Save automatically generated materials to disk, allowing reuse across [FuncGodotMap] nodes. [i]NOTE: Materials do not use the Default Material settings after saving.[/i]
 @export var save_generated_materials: bool = true
 

--- a/addons/func_godot/src/util/func_godot_texture_loader.gd
+++ b/addons/func_godot/src/util/func_godot_texture_loader.gd
@@ -118,9 +118,6 @@ func create_material(texture_name: String) -> Material:
 	if not texture:
 		return material
 	
-	if material is BaseMaterial3D:
-		material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED if map_settings.unshaded else BaseMaterial3D.SHADING_MODE_PER_PIXEL
-	
 	if material is StandardMaterial3D:
 		material.set_texture(StandardMaterial3D.TEXTURE_ALBEDO, texture)
 	elif material is ShaderMaterial && map_settings.default_material_albedo_uniform != "":


### PR DESCRIPTION
The `unshaded` property in FuncGodotMapSettings was a carryover from Qodot. Texture Loader would override the Default Material's shading parameter when building a new material. There isn't much point to this, and in fact doesn't support vertex shading feature for new materials, even if the default material base had it set.

With this PR, Texture Loader no longer overrides the Default Material's shading parameter, and the `unshaded` property no longer exists in Map Settings.

This should not be a major breaking change, as it will only affect new materials generated by FuncGodot. If you wish to use unshaded materials in your map, be sure to change your Default Material.