### PR TITLE
Allows automatically applying Node properties directly to the Node. 

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -22,6 +22,9 @@ var prefix: String = ""
 ## Key value pair properties that will appear in the map editor. After building the FuncGodotMap in Godot, these properties will be added to a Dictionary that gets applied to the generated Node, as long as that Node is a tool script with an exported `func_godot_properties` Dictionary.
 @export var class_properties : Dictionary = {}
 
+## Used to automatically apply properties to node.
+@export var override_node_properties : bool = false
+
 ## Descriptions for previously defined key value pair properties.
 @export var class_property_descriptions : Dictionary = {}
 

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -22,11 +22,11 @@ var prefix: String = ""
 ## Key value pair properties that will appear in the map editor. After building the FuncGodotMap in Godot, these properties will be added to a Dictionary that gets applied to the generated Node, as long as that Node is a tool script with an exported `func_godot_properties` Dictionary.
 @export var class_properties : Dictionary = {}
 
-## Used to automatically apply properties to node.
-@export var override_node_properties : bool = false
-
 ## Descriptions for previously defined key value pair properties.
 @export var class_property_descriptions : Dictionary = {}
+
+## Used to automatically apply properties to node.
+@export var auto_apply_to_matching_node_properties : bool = false
 
 ## Appearance properties for the map editor. See the [**Valve FGD**](https://developer.valvesoftware.com/wiki/FGD#Entity_Description) and [**TrenchBroom**](https://trenchbroom.github.io/manual/latest/#display-models-for-entities) documentation for more information.
 @export var meta_properties : Dictionary = {

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -25,7 +25,7 @@ var prefix: String = ""
 ## Descriptions for previously defined key value pair properties.
 @export var class_property_descriptions : Dictionary = {}
 
-## Used to automatically apply properties to node.
+## Automatically applies entity class properties to matching properties in the generated node. When using this feature, class properties need to be the correct type or you may run into errors on map build.
 @export var auto_apply_to_matching_node_properties : bool = false
 
 ## Appearance properties for the map editor. See the [**Valve FGD**](https://developer.valvesoftware.com/wiki/FGD#Entity_Description) and [**TrenchBroom**](https://trenchbroom.github.io/manual/latest/#display-models-for-entities) documentation for more information.

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -1007,6 +1007,11 @@ func apply_properties_and_finish() -> void:
 		
 		if 'func_godot_properties' in entity_node:
 			entity_node.func_godot_properties = properties
+
+		if override_node_properties:
+			for i in properties:
+				if i in entity_node:
+					entity_node[i] = properties[i]
 		
 		if entity_node.has_method("_func_godot_apply_properties"):
 			entity_node.call("_func_godot_apply_properties", properties)

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -1008,7 +1008,7 @@ func apply_properties_and_finish() -> void:
 		if 'func_godot_properties' in entity_node:
 			entity_node.func_godot_properties = properties
 
-		if override_node_properties:
+		if auto_apply_to_matching_node_properties:
 			for i in properties:
 				if i in entity_node:
 					entity_node[i] = properties[i]

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -1009,9 +1009,12 @@ func apply_properties_and_finish() -> void:
 			entity_node.func_godot_properties = properties
 
 		if auto_apply_to_matching_node_properties:
-			for i in properties:
-				if i in entity_node:
-					entity_node[i] = properties[i]
+			for property in properties:
+				if property in entity_node:
+					if typeof(entity_node.get(property)) == typeof(properties[property]):
+						entity_node.set(property, properties[property])
+					else:
+						push_error("Entity %s property \'%s\' type mismatch with matching generated node property." % [entity_node.name, property])
 		
 		if entity_node.has_method("_func_godot_apply_properties"):
 			entity_node.call("_func_godot_apply_properties", properties)


### PR DESCRIPTION
Adds a override_node_properties bool to FGD Entity. Map generator read apply this value directly to a node if there is a matching property name. If that property is a different type, it will cause an map build error.