### PR TITLE
Typed `Array[Resource]` to Arrays of typed classes

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -17,7 +17,7 @@ var prefix: String = ""
 @export var func_godot_internal : bool = false
 
 ## FuncGodotFGDBaseClass resources to inherit [member class_properties] and [member class_descriptions] from.
-@export var base_classes: Array[Resource] = []
+@export var base_classes: Array[FuncGodotFGDBaseClass] = []
 
 ## Key value pair properties that will appear in the map editor. After building the FuncGodotMap in Godot, these properties will be added to a Dictionary that gets applied to the generated Node, as long as that Node is a tool script with an exported `func_godot_properties` Dictionary.
 @export var class_properties : Dictionary = {}

--- a/addons/func_godot/src/map/func_godot_map_settings.gd
+++ b/addons/func_godot/src/map/func_godot_map_settings.gd
@@ -36,8 +36,8 @@ var scale_factor: float = 0.03125
 ## Optional path for the origin texture, relative to [member base_texture_dir]. Brush faces textured with the origin texture will have those faces removed from the generated [MeshInstance3D]. The bounds of these faces will be used to calculate the origin point of the entity.
 @export var origin_texture: String = "special/origin"
 
-## Optional [QuakeWADFile] resources to apply textures from. See the [Quake Wiki](https://quakewiki.org/wiki/Texture_Wad) for more information on Quake Texture WADs.
-@export var texture_wads: Array[Resource] = []
+## Optional [QuakeWadFile] resources to apply textures from. See the [Quake Wiki](https://quakewiki.org/wiki/Texture_Wad) for more information on Quake Texture WADs.
+@export var texture_wads: Array[QuakeWadFile] = []
 
 @export_category("Materials")
 

--- a/addons/func_godot/src/netradiant_custom/netradiant_custom_gamepack_config.gd
+++ b/addons/func_godot/src/netradiant_custom/netradiant_custom_gamepack_config.gd
@@ -26,7 +26,7 @@ extends Resource
 @export var fgd_file : FuncGodotFGDFile = preload("res://addons/func_godot/fgd/func_godot_fgd.tres")
 
 ## [NetRadiantCustomShader] resources for shader file generation.
-@export var netradiant_custom_shaders : Array[Resource] = [
+@export var netradiant_custom_shaders : Array[NetRadiantCustomShader] = [
 	preload("res://addons/func_godot/game_config/netradiant_custom/netradiant_custom_shader_clip.tres"),
 	preload("res://addons/func_godot/game_config/netradiant_custom/netradiant_custom_shader_skip.tres"),
 	preload("res://addons/func_godot/game_config/netradiant_custom/netradiant_custom_shader_origin.tres")

--- a/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
+++ b/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
@@ -58,10 +58,10 @@ enum GameConfigVersion {
 @export_category("Tags")
 
 ## TrenchBroomTag resources that apply to brush entities.
-@export var brush_tags : Array[Resource] = []
+@export var brush_tags : Array[TrenchBroomTag] = []
 
 ## TrenchBroomTag resources that apply to brush faces.
-@export var brushface_tags : Array[Resource] = [
+@export var brushface_tags : Array[TrenchBroomTag] = [
 	preload("res://addons/func_godot/game_config/trenchbroom/tb_face_tag_clip.tres"),
 	preload("res://addons/func_godot/game_config/trenchbroom/tb_face_tag_skip.tres"),
 	preload("res://addons/func_godot/game_config/trenchbroom/tb_face_tag_origin.tres")


### PR DESCRIPTION
Changes `Array[Resource]` to expected types. Makes it easier to add new assets. But blocks dragged existing assets in.

This bug engine bug is blocking this merge from being accepted: https://github.com/godotengine/godot/issues/92666