### PR TITLE
Add options for building mesh/collision data into metadata of generated nodes

### DIFF
--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -90,6 +90,8 @@ func gather_entity_concave_collision_surfaces(entity_idx: int) -> void:
 	surface_gatherer.reset_params()
 	surface_gatherer.split_type = FuncGodotSurfaceGatherer.SurfaceSplitType.NONE
 	surface_gatherer.entity_filter_idx = entity_idx
+	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+	surface_gatherer.metadata_skip_flags |= MFlags.COLLISION_SHAPE_TO_FACE_RANGE_MAP
 	surface_gatherer.set_skip_filter_texture(map_settings.skip_texture)
 	surface_gatherer.set_origin_filter_texture(map_settings.origin_texture)
 	surface_gatherer.run()

--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -3,12 +3,12 @@ class_name FuncGodot extends RefCounted
 var map_data:= FuncGodotMapData.new()
 var map_parser:= FuncGodotMapParser.new(map_data)
 var geo_generator = preload("res://addons/func_godot/src/core/func_godot_geo_generator.gd").new(map_data)
-var surface_gatherer:= FuncGodotSurfaceGatherer.new(map_data)
 var map_settings: FuncGodotMapSettings = null:
 	set(new):
 		if not new or new == map_settings: return
-		surface_gatherer.scale_factor = new.scale_factor
+		surface_gatherer.map_settings = new
 		map_settings = new
+var surface_gatherer:= FuncGodotSurfaceGatherer.new(map_data, map_settings)
 
 func load_map(filename: String, keep_tb_groups: bool) -> void:
 	map_parser.load_map(filename, keep_tb_groups)
@@ -64,7 +64,7 @@ func get_entity_dicts() -> Array:
 	return ent_dicts
 
 func gather_texture_surfaces(texture_name: String) -> Dictionary:
-	var sg: FuncGodotSurfaceGatherer = FuncGodotSurfaceGatherer.new(map_data)
+	var sg: FuncGodotSurfaceGatherer = FuncGodotSurfaceGatherer.new(map_data, map_settings)
 	sg.reset_params()
 	sg.split_type = FuncGodotSurfaceGatherer.SurfaceSplitType.ENTITY
 	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags

--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -24,7 +24,8 @@ func set_entity_definitions(entity_defs: Dictionary) -> void:
 		var classname: String = entity_defs.keys()[i]
 		var spawn_type: int = entity_defs.values()[i].get("spawn_type", FuncGodotMapData.FuncGodotEntitySpawnType.ENTITY)
 		var origin_type: int = entity_defs.values()[i].get("origin_type", FuncGodotMapData.FuncGodotEntityOriginType.BOUNDS_CENTER)
-		map_data.set_entity_types_by_classname(classname, spawn_type, origin_type)
+		var metadata_inclusion_flags: int = entity_defs.values()[i]["metadata_inclusion_flags"]
+		map_data.set_entity_types_by_classname(classname, spawn_type, origin_type, metadata_inclusion_flags)
 
 func get_texture_info(texture_name: String) -> FuncGodotMapData.FuncGodotTextureType:
 	if texture_name == map_settings.origin_texture:

--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -4,7 +4,11 @@ var map_data:= FuncGodotMapData.new()
 var map_parser:= FuncGodotMapParser.new(map_data)
 var geo_generator = preload("res://addons/func_godot/src/core/func_godot_geo_generator.gd").new(map_data)
 var surface_gatherer:= FuncGodotSurfaceGatherer.new(map_data)
-var map_settings: FuncGodotMapSettings = null
+var map_settings: FuncGodotMapSettings = null:
+	set(new):
+		if not new or new == map_settings: return
+		surface_gatherer.scale_factor = new.scale_factor
+		map_settings = new
 
 func load_map(filename: String, keep_tb_groups: bool) -> void:
 	map_parser.load_map(filename, keep_tb_groups)
@@ -24,7 +28,7 @@ func set_entity_definitions(entity_defs: Dictionary) -> void:
 		var classname: String = entity_defs.keys()[i]
 		var spawn_type: int = entity_defs.values()[i].get("spawn_type", FuncGodotMapData.FuncGodotEntitySpawnType.ENTITY)
 		var origin_type: int = entity_defs.values()[i].get("origin_type", FuncGodotMapData.FuncGodotEntityOriginType.BOUNDS_CENTER)
-		var metadata_inclusion_flags: int = entity_defs.values()[i]["metadata_inclusion_flags"]
+		var metadata_inclusion_flags: int = entity_defs.values()[i].get("metadata_inclusion_flags", FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.NONE)
 		map_data.set_entity_types_by_classname(classname, spawn_type, origin_type, metadata_inclusion_flags)
 
 func get_texture_info(texture_name: String) -> FuncGodotMapData.FuncGodotTextureType:

--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -67,7 +67,6 @@ func gather_texture_surfaces(texture_name: String) -> Dictionary:
 	var sg: FuncGodotSurfaceGatherer = FuncGodotSurfaceGatherer.new(map_data)
 	sg.reset_params()
 	sg.split_type = FuncGodotSurfaceGatherer.SurfaceSplitType.ENTITY
-	sg.build_entity_index_ranges = true
 	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
 	sg.metadata_skip_flags = MFlags.TEXTURES | MFlags.COLLISION_SHAPE_TO_FACE_RANGE_MAP
 	sg.set_texture_filter(texture_name)

--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -28,7 +28,7 @@ func set_entity_definitions(entity_defs: Dictionary) -> void:
 		var classname: String = entity_defs.keys()[i]
 		var spawn_type: int = entity_defs.values()[i].get("spawn_type", FuncGodotMapData.FuncGodotEntitySpawnType.ENTITY)
 		var origin_type: int = entity_defs.values()[i].get("origin_type", FuncGodotMapData.FuncGodotEntityOriginType.BOUNDS_CENTER)
-		var metadata_inclusion_flags: int = entity_defs.values()[i].get("metadata_inclusion_flags", FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.NONE)
+		var metadata_inclusion_flags: int = entity_defs.values()[i].get("metadata_inclusion_flags", FuncGodotMapData.FuncGodotEntityMetadataInclusionFlags.NONE)
 		map_data.set_entity_types_by_classname(classname, spawn_type, origin_type, metadata_inclusion_flags)
 
 func get_texture_info(texture_name: String) -> FuncGodotMapData.FuncGodotTextureType:
@@ -67,7 +67,7 @@ func gather_texture_surfaces(texture_name: String) -> Dictionary:
 	var sg: FuncGodotSurfaceGatherer = FuncGodotSurfaceGatherer.new(map_data, map_settings)
 	sg.reset_params()
 	sg.split_type = FuncGodotSurfaceGatherer.SurfaceSplitType.ENTITY
-	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+	const MFlags = FuncGodotMapData.FuncGodotEntityMetadataInclusionFlags
 	sg.metadata_skip_flags = MFlags.TEXTURES | MFlags.COLLISION_SHAPE_TO_FACE_RANGE_MAP
 	sg.set_texture_filter(texture_name)
 	sg.set_clip_filter_texture(map_settings.clip_texture)
@@ -90,7 +90,7 @@ func gather_entity_concave_collision_surfaces(entity_idx: int) -> void:
 	surface_gatherer.reset_params()
 	surface_gatherer.split_type = FuncGodotSurfaceGatherer.SurfaceSplitType.NONE
 	surface_gatherer.entity_filter_idx = entity_idx
-	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+	const MFlags = FuncGodotMapData.FuncGodotEntityMetadataInclusionFlags
 	surface_gatherer.metadata_skip_flags |= MFlags.COLLISION_SHAPE_TO_FACE_RANGE_MAP
 	surface_gatherer.set_skip_filter_texture(map_settings.skip_texture)
 	surface_gatherer.set_origin_filter_texture(map_settings.origin_texture)

--- a/addons/func_godot/src/core/func_godot.gd
+++ b/addons/func_godot/src/core/func_godot.gd
@@ -63,16 +63,22 @@ func get_entity_dicts() -> Array:
 	
 	return ent_dicts
 
-func gather_texture_surfaces(texture_name: String) -> Array:
+func gather_texture_surfaces(texture_name: String) -> Dictionary:
 	var sg: FuncGodotSurfaceGatherer = FuncGodotSurfaceGatherer.new(map_data)
 	sg.reset_params()
 	sg.split_type = FuncGodotSurfaceGatherer.SurfaceSplitType.ENTITY
+	sg.build_entity_index_ranges = true
+	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+	sg.metadata_skip_flags = MFlags.TEXTURES | MFlags.COLLISION_SHAPE_TO_FACE_RANGE_MAP
 	sg.set_texture_filter(texture_name)
 	sg.set_clip_filter_texture(map_settings.clip_texture)
 	sg.set_skip_filter_texture(map_settings.skip_texture)
 	sg.set_origin_filter_texture(map_settings.origin_texture)
 	sg.run()
-	return fetch_surfaces(sg)
+	return {
+		surfaces = fetch_surfaces(sg),
+		metadata = sg.out_metadata,
+	}
 
 func gather_entity_convex_collision_surfaces(entity_idx: int) -> void:
 	surface_gatherer.reset_params()

--- a/addons/func_godot/src/core/func_godot_map_data.gd
+++ b/addons/func_godot/src/core/func_godot_map_data.gd
@@ -66,7 +66,7 @@ enum FuncGodotEntityMetdataInclusionFlags {
 	VERTEX = 2,
 	FACE_POSITION = 4,
 	FACE_NORMAL = 8,
-	FACE_SHAPE_INDEX = 16,
+	COLLISION_SHAPE_TO_FACE_RANGE_MAP = 16,
 }
 
 enum FuncGodotTextureType {

--- a/addons/func_godot/src/core/func_godot_map_data.gd
+++ b/addons/func_godot/src/core/func_godot_map_data.gd
@@ -62,11 +62,12 @@ enum FuncGodotEntityOriginType {
 
 enum FuncGodotEntityMetdataInclusionFlags {
 	NONE = 0,
-	TEXTURES = 1,
-	VERTEX = 2,
-	FACE_POSITION = 4,
-	FACE_NORMAL = 8,
-	COLLISION_SHAPE_TO_FACE_RANGE_MAP = 16,
+	ENTITY_INDEX_RANGES = 1,
+	TEXTURES = 2,
+	VERTEX = 4,
+	FACE_POSITION = 8,
+	FACE_NORMAL = 16,
+	COLLISION_SHAPE_TO_FACE_RANGE_MAP = 32,
 }
 
 enum FuncGodotTextureType {

--- a/addons/func_godot/src/core/func_godot_map_data.gd
+++ b/addons/func_godot/src/core/func_godot_map_data.gd
@@ -26,9 +26,10 @@ func find_texture(texture_name: String) -> int:
 			return i
 	return -1
 
-func set_entity_types_by_classname(classname: String, spawn_type: int, origin_type: int) -> void:
+func set_entity_types_by_classname(classname: String, spawn_type: int, origin_type: int, meta_flags: int) -> void:
 	for entity in entities:
 		if entity.properties.has("classname") and entity.properties["classname"] == classname:
+			entity.metadata_inclusion_flags = meta_flags as FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
 			entity.spawn_type = spawn_type as FuncGodotMapData.FuncGodotEntitySpawnType
 			if entity.spawn_type == FuncGodotMapData.FuncGodotEntitySpawnType.ENTITY:
 				entity.origin_type = origin_type as FuncGodotMapData.FuncGodotEntityOriginType
@@ -57,6 +58,15 @@ enum FuncGodotEntityOriginType {
 	BOUNDS_CENTER = 4,
 	BOUNDS_MINS = 5,
 	BOUNDS_MAXS = 6,
+}
+
+enum FuncGodotEntityMetdataInclusionFlags {
+	NONE = 0,
+	TEXTURES = 1,
+	VERTEX = 2,
+	FACE_POSITION = 4,
+	FACE_NORMAL = 8,
+	FACE_SHAPE_INDEX = 16,
 }
 
 enum FuncGodotTextureType {
@@ -111,6 +121,7 @@ class FuncGodotEntity:
 	var center: Vector3
 	var spawn_type: FuncGodotEntitySpawnType
 	var origin_type: FuncGodotEntityOriginType
+	var metadata_inclusion_flags: FuncGodotEntityMetdataInclusionFlags
 	
 class FuncGodotFaceVertex:
 	var vertex: Vector3

--- a/addons/func_godot/src/core/func_godot_map_data.gd
+++ b/addons/func_godot/src/core/func_godot_map_data.gd
@@ -29,7 +29,7 @@ func find_texture(texture_name: String) -> int:
 func set_entity_types_by_classname(classname: String, spawn_type: int, origin_type: int, meta_flags: int) -> void:
 	for entity in entities:
 		if entity.properties.has("classname") and entity.properties["classname"] == classname:
-			entity.metadata_inclusion_flags = meta_flags as FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+			entity.metadata_inclusion_flags = meta_flags as FuncGodotMapData.FuncGodotEntityMetadataInclusionFlags
 			entity.spawn_type = spawn_type as FuncGodotMapData.FuncGodotEntitySpawnType
 			if entity.spawn_type == FuncGodotMapData.FuncGodotEntitySpawnType.ENTITY:
 				entity.origin_type = origin_type as FuncGodotMapData.FuncGodotEntityOriginType
@@ -60,7 +60,7 @@ enum FuncGodotEntityOriginType {
 	BOUNDS_MAXS = 6,
 }
 
-enum FuncGodotEntityMetdataInclusionFlags {
+enum FuncGodotEntityMetadataInclusionFlags {
 	NONE = 0,
 	ENTITY_INDEX_RANGES = 1,
 	TEXTURES = 2,
@@ -122,7 +122,7 @@ class FuncGodotEntity:
 	var center: Vector3
 	var spawn_type: FuncGodotEntitySpawnType
 	var origin_type: FuncGodotEntityOriginType
-	var metadata_inclusion_flags: FuncGodotEntityMetdataInclusionFlags
+	var metadata_inclusion_flags: FuncGodotEntityMetadataInclusionFlags
 	
 class FuncGodotFaceVertex:
 	var vertex: Vector3

--- a/addons/func_godot/src/core/func_godot_surface_gatherer.gd
+++ b/addons/func_godot/src/core/func_godot_surface_gatherer.gd
@@ -70,7 +70,7 @@ func run() -> void:
 	
 	var index_offset: int = 0
 	var entity_face_range: Vector2i = Vector2i.ZERO
-	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+	const MFlags = FuncGodotMapData.FuncGodotEntityMetadataInclusionFlags
 	var build_entity_index_ranges: bool = not metadata_skip_flags & MFlags.ENTITY_INDEX_RANGES
 	var surf: FuncGodotMapData.FuncGodotFaceGeometry
 	
@@ -210,7 +210,7 @@ func reset_params() -> void:
 	texture_filter_idx = -1
 	clip_filter_texture_idx = -1
 	skip_filter_texture_idx = -1
-	metadata_skip_flags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.ENTITY_INDEX_RANGES
+	metadata_skip_flags = FuncGodotMapData.FuncGodotEntityMetadataInclusionFlags.ENTITY_INDEX_RANGES
 
 # nested
 enum SurfaceSplitType{

--- a/addons/func_godot/src/core/func_godot_surface_gatherer.gd
+++ b/addons/func_godot/src/core/func_godot_surface_gatherer.gd
@@ -118,7 +118,7 @@ func run() -> void:
 					var normal := Vector3(face.plane_normal.y, face.plane_normal.z, face.plane_normal.x)
 					for i in num_tris:
 						normals.append(normal)
-				if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.FACE_SHAPE_INDEX:
+				if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.COLLISION_SHAPE_TO_FACE_RANGE_MAP:
 					total_brush_tris += num_tris
 				if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.TEXTURES:
 					var texname := StringName(map_data.textures[face.texture_idx].name)
@@ -130,7 +130,7 @@ func run() -> void:
 						# common case, faces with textures are next to each other
 						index = texture_names.size() - 1
 					else:
-						var texture_name_index := texture_names.find(texname)
+						var texture_name_index: int = texture_names.find(texname)
 						if texture_name_index == -1:
 							index = texture_names.size()
 							texture_names.append(texname)
@@ -151,12 +151,12 @@ func run() -> void:
 				for i in range(num_tris * 3):
 					surf.indicies.append(face_geo.indicies[i] + index_offset)
 					if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.VERTEX:
-						var vertex := surf.vertices[surf.indicies.back()].vertex
+						var vertex: Vector3 = surf.vertices[surf.indicies.back()].vertex
 						vertices.append(Vector3(vertex.y, vertex.z, vertex.x) * scale_factor)
 				
 				index_offset += face_geo.vertices.size()
 			
-			if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.FACE_SHAPE_INDEX:
+			if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.COLLISION_SHAPE_TO_FACE_RANGE_MAP:
 				entity_face_range.x = entity_face_range.y
 				entity_face_range.y = entity_face_range.x + total_brush_tris
 				shape_index_ranges.append(entity_face_range)

--- a/addons/func_godot/src/core/func_godot_surface_gatherer.gd
+++ b/addons/func_godot/src/core/func_godot_surface_gatherer.gd
@@ -1,7 +1,7 @@
 class_name FuncGodotSurfaceGatherer extends RefCounted
 
 var map_data: FuncGodotMapData
-var scale_factor: float
+var map_settings: FuncGodotMapSettings
 var split_type: SurfaceSplitType = SurfaceSplitType.NONE
 var entity_filter_idx: int = -1
 var texture_filter_idx: int = -1
@@ -13,8 +13,9 @@ var metadata_skip_flags: int
 var out_surfaces: Array[FuncGodotMapData.FuncGodotFaceGeometry]
 var out_metadata: Dictionary
 
-func _init(in_map_data: FuncGodotMapData) -> void:
+func _init(in_map_data: FuncGodotMapData, in_map_settings: FuncGodotMapSettings) -> void:
 	map_data = in_map_data
+	map_settings = in_map_settings
 
 func set_texture_filter(texture_name: String) -> void:
 	texture_filter_idx = map_data.find_texture(texture_name)
@@ -154,7 +155,7 @@ func run() -> void:
 					var avg_vertexpos := Vector3.ZERO
 					# NOTE: averaging face_geo.vertices to get face position assumes that all vertices of a face are along its edges
 					for vertex in face_geo.vertices:
-						avg_vertexpos += Vector3(vertex.vertex.y, vertex.vertex.z, vertex.vertex.x) * scale_factor
+						avg_vertexpos += Vector3(vertex.vertex.y, vertex.vertex.z, vertex.vertex.x) * map_settings.scale_factor
 					avg_vertexpos /= face_geo.vertices.size()
 					for i in num_tris:
 						positions.append(avg_vertexpos)
@@ -163,7 +164,7 @@ func run() -> void:
 					surf.indicies.append(face_geo.indicies[i] + index_offset)
 					if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.VERTEX:
 						var vertex: Vector3 = surf.vertices[surf.indicies.back()].vertex
-						vertices.append(Vector3(vertex.y, vertex.z, vertex.x) * scale_factor)
+						vertices.append(Vector3(vertex.y, vertex.z, vertex.x) * map_settings.scale_factor)
 				
 				index_offset += face_geo.vertices.size()
 			

--- a/addons/func_godot/src/core/func_godot_surface_gatherer.gd
+++ b/addons/func_godot/src/core/func_godot_surface_gatherer.gd
@@ -8,7 +8,6 @@ var texture_filter_idx: int = -1
 var clip_filter_texture_idx: int
 var skip_filter_texture_idx: int
 var origin_filter_texture_idx: int
-var build_entity_index_ranges: bool
 var metadata_skip_flags: int
 
 var out_surfaces: Array[FuncGodotMapData.FuncGodotFaceGeometry]
@@ -70,6 +69,8 @@ func run() -> void:
 	
 	var index_offset: int = 0
 	var entity_face_range: Vector2i = Vector2i.ZERO
+	const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+	var build_entity_index_ranges: bool = not metadata_skip_flags & MFlags.ENTITY_INDEX_RANGES
 	var surf: FuncGodotMapData.FuncGodotFaceGeometry
 	
 	if split_type == SurfaceSplitType.NONE:
@@ -81,7 +82,6 @@ func run() -> void:
 		var entity_geo:= map_data.entity_geo[e]
 		var shape_face_range := Vector2i.ZERO
 		var total_entity_tris := 0
-		const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
 		var include_normals_metadata: bool = not metadata_skip_flags & MFlags.FACE_NORMAL and entity.metadata_inclusion_flags & MFlags.FACE_NORMAL
 		var include_vertices_metadata: bool = not metadata_skip_flags & MFlags.VERTEX and entity.metadata_inclusion_flags & MFlags.VERTEX
 		var include_textures_metadata: bool = not metadata_skip_flags & MFlags.TEXTURES and entity.metadata_inclusion_flags & MFlags.TEXTURES
@@ -202,8 +202,7 @@ func reset_params() -> void:
 	texture_filter_idx = -1
 	clip_filter_texture_idx = -1
 	skip_filter_texture_idx = -1
-	build_entity_index_ranges = false
-	metadata_skip_flags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.NONE
+	metadata_skip_flags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.ENTITY_INDEX_RANGES
 
 # nested
 enum SurfaceSplitType{

--- a/addons/func_godot/src/core/func_godot_surface_gatherer.gd
+++ b/addons/func_godot/src/core/func_godot_surface_gatherer.gd
@@ -152,26 +152,22 @@ func run() -> void:
 					for i in num_tris:
 						textures.append(index)
 				
-				var last_index: int = -1
-				var avg_vertexpos := Vector3.ZERO
-				var total_vertexpos: int = 0
+				var avg_vertex_pos := Vector3.ZERO
+				var avg_vertex_pos_ct: int = 0
 				for i in range(num_tris * 3):
 					surf.indicies.append(face_geo.indicies[i] + index_offset)
+					var vertex: Vector3 = surf.vertices[surf.indicies.back()].vertex
+					vertex = Vector3(vertex.y, vertex.z, vertex.x) * map_settings.scale_factor
 					if include_vertices_metadata:
-						var vertex: Vector3 = surf.vertices[surf.indicies.back()].vertex
-						vertices.append(Vector3(vertex.y, vertex.z, vertex.x) * map_settings.scale_factor)
+						vertices.append(vertex)
 					if include_positions_metadata:
-						var index := face_geo.indicies[i] + index_offset
-						# NOTE: this relies on new indices always being in ascending order
-						if index > last_index:
-							var vertex: Vector3 = surf.vertices[index].vertex
-							avg_vertexpos += Vector3(vertex.y, vertex.z, vertex.x) * map_settings.scale_factor
-							total_vertexpos += 1
-
-				if include_positions_metadata:
-					avg_vertexpos /= total_vertexpos
-					for i in num_tris:
-						positions.append(avg_vertexpos)
+						avg_vertex_pos_ct += 1
+						avg_vertex_pos += vertex
+						if avg_vertex_pos_ct == 3:
+							avg_vertex_pos /= 3
+							positions.append(avg_vertex_pos)
+							avg_vertex_pos = Vector3.ZERO
+							avg_vertex_pos_ct = 0
 				
 				index_offset += face_geo.vertices.size()
 			

--- a/addons/func_godot/src/core/func_godot_surface_gatherer.gd
+++ b/addons/func_godot/src/core/func_godot_surface_gatherer.gd
@@ -151,20 +151,27 @@ func run() -> void:
 					# metadata addresses triangles, so we have to duplicate the info for each tri
 					for i in num_tris:
 						textures.append(index)
-				if include_positions_metadata:
-					var avg_vertexpos := Vector3.ZERO
-					# NOTE: averaging face_geo.vertices to get face position assumes that all vertices of a face are along its edges
-					for vertex in face_geo.vertices:
-						avg_vertexpos += Vector3(vertex.vertex.y, vertex.vertex.z, vertex.vertex.x) * map_settings.scale_factor
-					avg_vertexpos /= face_geo.vertices.size()
-					for i in num_tris:
-						positions.append(avg_vertexpos)
 				
+				var last_index: int = -1
+				var avg_vertexpos := Vector3.ZERO
+				var total_vertexpos: int = 0
 				for i in range(num_tris * 3):
 					surf.indicies.append(face_geo.indicies[i] + index_offset)
-					if entity.metadata_inclusion_flags & FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags.VERTEX:
+					if include_vertices_metadata:
 						var vertex: Vector3 = surf.vertices[surf.indicies.back()].vertex
 						vertices.append(Vector3(vertex.y, vertex.z, vertex.x) * map_settings.scale_factor)
+					if include_positions_metadata:
+						var index := face_geo.indicies[i] + index_offset
+						# NOTE: this relies on new indices always being in ascending order
+						if index > last_index:
+							var vertex: Vector3 = surf.vertices[index].vertex
+							avg_vertexpos += Vector3(vertex.y, vertex.z, vertex.x) * map_settings.scale_factor
+							total_vertexpos += 1
+
+				if include_positions_metadata:
+					avg_vertexpos /= total_vertexpos
+					for i in num_tris:
+						positions.append(avg_vertexpos)
 				
 				index_offset += face_geo.vertices.size()
 			

--- a/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
@@ -55,6 +55,31 @@ enum CollisionShapeType {
 ## The collision margin for the Solid Class' collision shapes. Not used in Godot Physics. See [Shape3D] for details.
 @export var collision_shape_margin: float = 0.04
 
+## The following properties tell FuncGodot to add data to the metadata of the generated node upon build. 
+## This data is parallelized, so that each element of the array is ordered to reference the same face in the mesh. 
+@export_category("Mesh Metadata")
+## Add a texture lookup table to the generated node's metadata on build. 
+## The data is split between an [Array] of [StringName] called `"texture_names"` containing all currently used texture materials 
+## and a [PackedInt32Array] called `"textures"` where each element is an index corresponding to the `"texture_names"` entries.
+@export var add_textures_metadata: bool = false
+## Add a [PackedVector3Array] called `"vertices"` in the generated node's metadata on build. 
+## This is a list of every vertex in the generated node's [MeshInstance3D]. Every 3 vertices represent a single face.
+@export var add_vertex_metadata: bool = false
+## Add a [PackedVector3Array] called `"positions"` in the generated node's metadata on build. 
+## This is a list of positions for each face, local to the generated node, calculated by averaging the vertices to find the face's center.
+@export var add_face_position_metadata = false
+## Add a [PackedVector3Array] called `"normals"` in the generated node's metadata on build. 
+## Contains a list of each face's normal.
+@export var add_face_normal_metadata = false
+## Add a [Dictionary] called `"shape_index_to_faces_range_map"` in the generated node's metadata on build. 
+## Contains keys of strings, which are the names of child [CollisionShape3D] nodes, and values of
+## Vector2i, where the x represents the starting index of that child's faces and the y represents the
+## ending index.
+## For example: [code]{ "entity_1_brush_0_collision_shape" : Vector2i(0, 15) }[/code] shows that this
+## solid class has been generated with one child collision shape named entity_1_brush_0_collision_shape
+## which is handling collision for the first 15 faces of the mesh.
+@export var add_face_shape_index_metadata = false
+
 @export_group("Scripting")
 ## An optional script file to attach to the node generated on map build.
 @export var script_class: Script

--- a/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
@@ -57,6 +57,8 @@ enum CollisionShapeType {
 
 ## The following properties tell FuncGodot to add data to the metadata of the generated node upon build. 
 ## This data is parallelized, so that each element of the array is ordered to reference the same face in the mesh. 
+## All of the data is stored in a dictionary in the node generated for the entity, in metadata entry
+## [code]"func_godot_mesh_data"[/code]
 @export_group("Mesh Metadata")
 ## Add a texture lookup table to the generated node's metadata on build. 
 ## The data is split between an [Array] of [StringName] called `"texture_names"` containing all currently used texture materials 
@@ -71,14 +73,14 @@ enum CollisionShapeType {
 ## Add a [PackedVector3Array] called `"normals"` in the generated node's metadata on build. 
 ## Contains a list of each face's normal.
 @export var add_face_normal_metadata = false
-## Add a [Dictionary] called `"shape_index_to_faces_range_map"` in the generated node's metadata on build. 
+## Add a [Dictionary] called `"collision_shape_to_face_range_map"` in the generated node's metadata on build. 
 ## Contains keys of strings, which are the names of child [CollisionShape3D] nodes, and values of
 ## Vector2i, where the x represents the starting index of that child's faces and the y represents the
 ## ending index.
 ## For example: [code]{ "entity_1_brush_0_collision_shape" : Vector2i(0, 15) }[/code] shows that this
 ## solid class has been generated with one child collision shape named entity_1_brush_0_collision_shape
 ## which is handling collision for the first 15 faces of the mesh.
-@export var add_face_shape_index_metadata = false
+@export var add_collision_shape_face_range_metadata = false
 
 @export_group("Scripting")
 ## An optional script file to attach to the node generated on map build.

--- a/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
@@ -79,7 +79,7 @@ enum CollisionShapeType {
 ## ending index.
 ## For example: [code]{ "entity_1_brush_0_collision_shape" : Vector2i(0, 15) }[/code] shows that this
 ## solid class has been generated with one child collision shape named entity_1_brush_0_collision_shape
-## which is handling collision for the first 15 faces of the mesh.
+## which handles the first 15 faces of the parts of the mesh with collision.
 @export var add_collision_shape_face_range_metadata = false
 
 @export_group("Scripting")

--- a/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
@@ -57,7 +57,7 @@ enum CollisionShapeType {
 
 ## The following properties tell FuncGodot to add data to the metadata of the generated node upon build. 
 ## This data is parallelized, so that each element of the array is ordered to reference the same face in the mesh. 
-@export_category("Mesh Metadata")
+@export_group("Mesh Metadata")
 ## Add a texture lookup table to the generated node's metadata on build. 
 ## The data is split between an [Array] of [StringName] called `"texture_names"` containing all currently used texture materials 
 ## and a [PackedInt32Array] called `"textures"` where each element is an index corresponding to the `"texture_names"` entries.

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -702,7 +702,7 @@ func build_entity_mesh_dict() -> Dictionary:
 
 			# build metadata, only if the node is set to not build collision. otherwise we are already
 			# building it in build_entity_collision_shapes
-			if entity_definition.collision_shape_type == FuncGodotFGDSolidClass.CollisionShapeType.NONE:
+			if entity_definition and entity_definition.collision_shape_type == FuncGodotFGDSolidClass.CollisionShapeType.NONE:
 				if not mesh.has_meta("func_godot_mesh_data"):
 					mesh.set_meta("func_godot_mesh_data", Dictionary())
 				var this_textures_metadata: Dictionary = texture_to_metadata_map[texture]

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -631,15 +631,23 @@ func build_entity_collision_shapes() -> void:
 			if entity_definition and entity_definition.add_collision_shape_face_range_metadata:
 				collision_shape_to_face_range_map[collision_shape.name] = Vector2i(0, entity_verts.size() / 3)
 
-		if entity_definition and (
-			entity_definition.add_collision_shape_face_range_metadata
-			or entity_definition.add_face_normal_metadata
-			or entity_definition.add_face_position_metadata
-			or entity_definition.add_textures_metadata
-			or entity_definition.add_vertex_metadata):
+		if entity_definition:
+			if not entity_definition.add_face_normal_metadata:
+				metadata.erase("normals")
+			if not entity_definition.add_face_position_metadata:
+				metadata.erase("positions")
+			if not entity_definition.add_textures_metadata:
+				metadata.erase("textures")
+				metadata.erase("texture_names")
+			if not entity_definition.add_vertex_metadata:
+				metadata.erase("vertices")
+
 			metadata.erase("shape_index_ranges") # cleanup intermediate / buffer
-			metadata["collision_shape_to_face_range_map"] = collision_shape_to_face_range_map
-			entity_nodes[entity_idx].set_meta("func_godot_mesh_data", metadata)
+			if entity_definition.add_collision_shape_face_range_metadata:
+				metadata["collision_shape_to_face_range_map"] = collision_shape_to_face_range_map
+
+			if not metadata.is_empty():
+				entity_nodes[entity_idx].set_meta("func_godot_mesh_data", metadata)
 
 ## Build Dictionary from entity indices to [ArrayMesh] instances
 func build_entity_mesh_dict() -> Dictionary:

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -317,9 +317,19 @@ func set_core_entity_definitions() -> void:
 	var core_ent_defs: Dictionary = {}
 	for classname in entity_definitions:
 		core_ent_defs[classname] = {}
-		if entity_definitions[classname] is FuncGodotFGDSolidClass:
-			core_ent_defs[classname]['spawn_type'] = entity_definitions[classname].spawn_type
-			core_ent_defs[classname]['origin_type'] = entity_definitions[classname].origin_type
+		var entity_definition: FuncGodotFGDEntityClass = entity_definitions[classname]
+		if entity_definition is FuncGodotFGDSolidClass:
+			core_ent_defs[classname]['spawn_type'] = entity_definition.spawn_type
+			core_ent_defs[classname]['origin_type'] = entity_definition.origin_type
+			
+			const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+			var flags := MFlags.NONE
+			if entity_definition.add_textures_metadata: flags |= MFlags.TEXTURES
+			if entity_definition.add_vertex_metadata: flags |= MFlags.VERTEX
+			if entity_definition.add_face_normal_metadata: flags |= MFlags.FACE_NORMAL
+			if entity_definition.add_face_position_metadata: flags |= MFlags.FACE_POSITION
+			if entity_definition.add_face_shape_index_metadata: flags |= MFlags.FACE_SHAPE_INDEX
+			core_ent_defs[classname]['metadata_inclusion_flags'] = flags
 	func_godot.set_entity_definitions(core_ent_defs)
 
 ## Generate geometry from map file

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -322,7 +322,7 @@ func set_core_entity_definitions() -> void:
 			core_ent_defs[classname]['spawn_type'] = entity_definition.spawn_type
 			core_ent_defs[classname]['origin_type'] = entity_definition.origin_type
 			
-			const MFlags = FuncGodotMapData.FuncGodotEntityMetdataInclusionFlags
+			const MFlags = FuncGodotMapData.FuncGodotEntityMetadataInclusionFlags
 			var flags := MFlags.NONE
 			if entity_definition.add_textures_metadata: flags |= MFlags.TEXTURES
 			if entity_definition.add_vertex_metadata: flags |= MFlags.VERTEX

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -629,8 +629,7 @@ func build_entity_collision_shapes() -> void:
 			collision_shape.set_shape(shape)
 			
 			if entity_definition and entity_definition.add_collision_shape_face_range_metadata:
-				# TODO: face shape stuff gets thrown away here, building the array in surface gatherer could be avoided altogether for concave
-				collision_shape_to_face_range_map[collision_shape.name] = Vector2i(0, face_shape_indices.back().y)
+				collision_shape_to_face_range_map[collision_shape.name] = Vector2i(0, entity_verts.size() / 3)
 
 		if entity_definition and (
 			entity_definition.add_collision_shape_face_range_metadata


### PR DESCRIPTION
These options can propagate data necessary for getting the texture on the part of a mesh corresponding to a collision.

Added as per discussion https://github.com/orgs/func-godot/discussions/59

Outstanding questions / known issues:
- I haven't tested this at runtime yet, so I'm sure there are some math issues. I'll get to that later this week, hopefully.
- I am uncertain if my method of finding average / center position for faces is correct. I'll find out when I test later, but please lmk if it is clearly wrong.
- The `shape_index_to_faces_range_map` provides redundant information for concave meshes, but currently it still gets built for them and then thrown away.
- I am passing scale factor to the surface gatherer so that it can do the map file -> godot translation in the loop. Feels like a bit of a hack but I wanted to avoid a second pass over anything.
- Since we address faces in the metadata by triangles, but `"textures"`, `"normals"`, and `"positions"` are the same for all triangles in the face of a brush, there can be quite a bit of duplication for those fields. If an index buffer was included, this would be fixed and appending vertex info would require no processing at all, as it could be copied straight from the result of `fetch_surfaces`.

On the example_basic scene, I rebuilt with all metadata enabled and file size went from 16KB to 20KB. I am going to test   this out on more complex levels later, and also measure runtime memory usage. I don't think its a concern but I like having a frame of reference. When the docs get updated it would be nice to provide some estimates of changes in disk/memory usage when enabling this feature in different capacities.
