### PR TITLE
add map settings property

### DIFF
--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -47,9 +47,9 @@ func _enter_tree() -> void:
 	
 	add_custom_type("FuncGodotMap", "Node3D", preload("res://addons/func_godot/src/map/func_godot_map.gd"), null)
 	
-	ProjectSettings.set("func_godot/map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
+	ProjectSettings.set("func_godot/default_map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
 	var property_info = {
-		"name": "func_godot/map_settings",
+		"name": "func_godot/default_map_settings",
 		"type": TYPE_STRING,
 		"hint": PROPERTY_HINT_FILE,
 		"hint_string": "*.tres"

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -46,6 +46,16 @@ func _enter_tree() -> void:
 	add_control_to_container(EditorPlugin.CONTAINER_INSPECTOR_BOTTOM, func_godot_map_progress_bar)
 	
 	add_custom_type("FuncGodotMap", "Node3D", preload("res://addons/func_godot/src/map/func_godot_map.gd"), null)
+	
+	ProjectSettings.set("func_godot/map_settings", "res://addons/func_godot/src/map/func_godot_map_settings.gd")
+	var property_info = {
+		"name": "func_godot/map_settings",
+		"type": TYPE_STRING_NAME,
+		"hint": PROPERTY_HINT_FILE,
+		"hint_string": "path to map settings"
+	}
+
+	ProjectSettings.add_property_info(property_info)
 
 func _exit_tree() -> void:
 	remove_custom_type("FuncGodotMap")

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -47,7 +47,7 @@ func _enter_tree() -> void:
 	
 	add_custom_type("FuncGodotMap", "Node3D", preload("res://addons/func_godot/src/map/func_godot_map.gd"), null)
 	
-	ProjectSettings.set("func_godot/map_settings", "res://addons/func_godot/src/map/func_godot_map_settings.gd")
+	ProjectSettings.set("func_godot/map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
 	var property_info = {
 		"name": "func_godot/map_settings",
 		"type": TYPE_STRING_NAME,

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -52,7 +52,7 @@ func _enter_tree() -> void:
 		"name": "func_godot/map_settings",
 		"type": TYPE_STRING,
 		"hint": PROPERTY_HINT_FILE,
-		"hint_string": "path to map settings"
+		"hint_string": "*.tres"
 	}
 
 	ProjectSettings.add_property_info(property_info)

--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -50,7 +50,7 @@ func _enter_tree() -> void:
 	ProjectSettings.set("func_godot/map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
 	var property_info = {
 		"name": "func_godot/map_settings",
-		"type": TYPE_STRING_NAME,
+		"type": TYPE_STRING,
 		"hint": PROPERTY_HINT_FILE,
 		"hint_string": "path to map settings"
 	}

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -29,7 +29,7 @@ signal unwrap_uv2_complete()
 var _map_file_internal: String = ""
 
 ## Map settings resource that defines map build scale, textures location, and more.
-@export var map_settings: FuncGodotMapSettings = load("res://addons/func_godot/func_godot_default_map_settings.tres")
+@export var map_settings: FuncGodotMapSettings = load(ProjectSettings.get_setting("func_godot/map_settings"))
 
 @export_category("Build")
 ## If true, print profiling data before and after each build step.


### PR DESCRIPTION
Adds Map Settings to Project Settings so you dont have to manually change the map settings each time a new Func Godot Map is added to a scene