### PR TITLE
Allow More Flexible Formatting in Entity Descriptions

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -98,7 +98,7 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 	res += " = " + classname
 	
 	if prefix != "@BaseClass": # having a description in BaseClasses crashes some editors
-		var normalized_description = description.replace("\n", " ").strip_edges() if prefix != "@BaseClass" else ""
+		var normalized_description = description.replace("\"", "\'")
 		if normalized_description != "":
 			res += " : \"%s\" " % [normalized_description]
 		else: # Having no description crashes some editors


### PR DESCRIPTION
Previously entity descriptions were explicitly limited to no special or escape characters. There seemed to be an assumption that the FGD format may not have supported escape characters. Additionally there was an unnecessary replacement of the `\n` escape character as it was immediately followed up by `strip_edges()` which removes `\n` anyway. There was also a superfluous check for the `@BaseClass` prefix value, which was already checked for in a previous conditional.

This PR changes the way the description is processed to only replace the one unsupported escape character: `\"` (descriptions are encapsulated by quote marks, and the FGD format doesn't actually support escape characters, Godot converts them when writing to the FGD file). All other escape characters and symbols appear to be supported by the FGD format, and so are allowed by FuncGodot.

This PR resolves #84 .