### PR TITLE
Scale Model Point Entities when Scale Expression set

### DIFF
--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -455,6 +455,19 @@ func build_entity_nodes() -> Array:
 							angles.y += angle
 						angles.y += 180
 						node.rotation_degrees = angles
+					if entity_definition is FuncGodotFGDModelPointClass:
+						if not entity_definition.scale_expression.is_empty() and entity_definition.scale_expression in properties:
+							var scale_str: String = properties[entity_definition.scale_expression]
+							if not scale_str.is_valid_float():
+								push_error("Value '%s' of scale expression '%s' not a valid float" % [
+									scale_str,
+									entity_definition.scale_expression,
+								])
+							elif not node is Node3D:
+								push_error("Node '%s' cannot be scaled by scale expression" % str(node))
+							else:
+								var s := scale_str.to_float() * map_settings.scale_factor
+								node.scale *= Vector3(s, s, s)
 				else:
 					node = Node3D.new()
 				if entity_definition.script_class:


### PR DESCRIPTION
The _scale expression_ setting can be used to allow a scaling key to be applied to entities in TrenchBroom, but the map built by func_godot does not reflect the size as shown in the map editor.

This change scales the generated node if a scale expression is defined and the entity's properties include a float value for that key. The final scale is affected by the map's inverse scale factor.

For example, with the default map inverse scale factor of 32 and a scaling expression of `scale`, an entity tagged with `scale = 8` in TrenchBroom results in a node scaled by one quarter.

![shot 2025-02-23 15 30 19@2x](https://github.com/user-attachments/assets/92e635dc-6706-46c0-b53d-65dbecfe24a7)

This is an unsolicited change so please do let me know if this is misguided or won't work for some reason.