### PR TITLE
Fix invalid container id when unregistering progress bar control

### DIFF
--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -74,7 +74,7 @@ func _exit_tree() -> void:
 		func_godot_map_control = null
 
 	if func_godot_map_progress_bar:
-		remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, func_godot_map_progress_bar)
+		remove_control_from_container(EditorPlugin.CONTAINER_INSPECTOR_BOTTOM, func_godot_map_progress_bar)
 		func_godot_map_progress_bar.queue_free()
 		func_godot_map_progress_bar = null
 


### PR DESCRIPTION
This PR fixes an error message being displayed when closing Godot editor or disabling func_godot plugin in the project settings: 
` scene/main/node.cpp:1602 - Condition "p_child->data.parent != this" is true.`

