### PR TITLE
Fix resource (materials, sounds, etc.) values not being strings in FGD files

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -178,7 +178,7 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 				prop_val = "\"\""
 			TYPE_OBJECT:
 				if value is Resource:
-					prop_val = value.resource_path
+					prop_val = "\"" + value.resource_path + "\""
 					if value is Material:
 						if target_editor != FuncGodotFGDFile.FuncGodotTargetMapEditors.JACK:
 							prop_type = "material"


### PR DESCRIPTION
I ran into an issue recently where I noticed that whenever I tried to load an FGD into TrenchBroom that had been generated with an object as a value, TrenchBroom would complain about the FGD being incorrectly formatted.
The error is:
```Could not load builtin entity definition file '"min-reprod.fgd"': At line 41, column 22: Expected integer, decimal, string, or ':', but got word (raw data: 'res')```
I've provided what I believe to be a minimal reproduction Godot project of the issue.
This PR just adds a couple of double quotes around the value, which fixes the aforementioned issue.

[Fg-min-reprod-object.zip](https://github.com/user-attachments/files/19617559/Fg-min-reprod-object.zip)
