### PR TITLE
Fix: Trenchbroom RC5 now has the correct orientation for model() classes

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
@@ -97,8 +97,6 @@ func _create_gltf_file(gltf_state: GLTFState, path: String, node: Node3D) -> boo
 	var gltf_document := GLTFDocument.new()
 	gltf_state.create_animations = false
 	
-	node.rotate_y(deg_to_rad(-90))
-	
 	# With TrenchBroom we can specify a scale expression, but for other editors we need to scale our models manually.
 	if target_map_editor != TargetMapEditor.TRENCHBROOM:
 		var scale_factor: Vector3 = Vector3.ONE

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -475,7 +475,6 @@ func build_entity_nodes() -> Array:
 							if not angle is float:
 								angle = float(angle)
 							angles.y += angle
-						angles.y += 180
 						node.rotation_degrees = angles
 					
 					if 'scale' in node and entity_definition.apply_scale_on_map_build:


### PR DESCRIPTION
I've removed the manual changes to the angles, since the axis conversions are now correct when you swap to RC5 your map will break.

Video showing the issue and the fix https://www.youtube.com/watch?v=t4tWzLAsNVo


You must do the following:
- update func_godot
- update trenchbroom
- go into your map and where you've used model point classes correct the angle

How can I test the assumptions here?
- Import this model into godot and func_godot  (https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/BoomBoxWithAxes) [BoomBoxWithAxes.glb.zip](https://github.com/user-attachments/files/20160204/BoomBoxWithAxes.glb.zip)

- Make a dummy entity with this as the scene file
- Export your FGD, and spawn the entity, it will be oriented 1:1 what it is in godot when you spawn it.
- You can verify this model in blender too and it will do the same.

Why did this work:
- we previously had to compensate for a 90 degree offset on items, there was an additional 180 degrees applied to flip an axis

Map files will need updated due to the manual flip being required once for Model classes.

Upstream trenchbroom issue I created last night:
https://github.com/TrenchBroom/TrenchBroom/issues/4853

This is a breaking change meaning you'll need to inform users of this, it sucks but it should only be needed once. It's why I spent an hour or two just verifying the rotation orders with this model. 

On the left there is a godot instance of the glb file, on the right there is a func godot model entity with the same glb exported and imported from .map
<img width="1057" alt="Screenshot 2025-05-12 at 12 24 59" src="https://github.com/user-attachments/assets/d3fa1bb1-307d-4ee2-bf71-7f3902454383" />

In trenchbroom RC5
<img width="270" alt="Screenshot 2025-05-12 at 12 25 35" src="https://github.com/user-attachments/assets/311f8799-edbd-4c6d-b07c-512fae3e5cbb" />


