### PR TITLE
Add Rotation Offset Property to Model Point Class

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
@@ -17,6 +17,8 @@ enum TargetMapEditor {
 @export var scale_expression : String = ""
 ## Model Point Class can override the 'size' meta property by auto-generating a value from the meshes' [AABB]. Proper generation requires 'scale_expression' set to a float or [Vector3]. **WARNING:** Generated size property unlikely to align cleanly to grid!
 @export var generate_size_property : bool = false
+## Degrees to rotate model prior to export. Different editors may handdle GLTF transformations differently. If your model isn't oriented correctly, try modifying this property.
+@export var rotation_offset: Vector3 = Vector3(0.0, 0.0, 0.0)
 ## Creates a .gdignore file in the model export folder to prevent Godot importing the display models. Only needs to be generated once.
 @export var generate_gd_ignore_file : bool = false :
 	get:
@@ -97,7 +99,9 @@ func _create_gltf_file(gltf_state: GLTFState, path: String, node: Node3D) -> boo
 	var gltf_document := GLTFDocument.new()
 	gltf_state.create_animations = false
 	
-	node.rotate_y(deg_to_rad(-90))
+	node.rotate_x(deg_to_rad(rotation_offset.x))
+	node.rotate_y(deg_to_rad(rotation_offset.y))
+	node.rotate_z(deg_to_rad(rotation_offset.z))
 	
 	# With TrenchBroom we can specify a scale expression, but for other editors we need to scale our models manually.
 	if target_map_editor != TargetMapEditor.TRENCHBROOM:


### PR DESCRIPTION
Model Point Class originally performed an auto rotation to the output model due to the differences between Quake's and Godot's coordinate systems (Quake uses +X forward while Godot uses -Z forward).

TrenchBroom recently changed how they display GLTF models, orienting them by having a GLTF model's +Z point towards +X.

https://github.com/TrenchBroom/TrenchBroom/pull/4843

This has the effect of nullifying the corrective rotation performed by Model Point Class, causing exported models in TrenchBroom to be oriented incorrectly.

However, FuncGodot is intended to be as editor agnostic as possible, and other editors like NetRadiant-Custom do not currently perform this rotation correction.

Additionally, FuncGodot using a hardcoded rotation assumes that developers will have their characters and other objects face towards -Z, but this may not always be the case. This assumption goes against one of FuncGodot's core tenets: that it should not design your game for you.

This PR adds a Rotation Offset property to Model Point Class, allowing developers to determine their own rotation offsets depending upon their choice of editor and personal design.