### PR TITLE
Prevent Texture Loader from Generating Origin Material

### DIFF
--- a/addons/func_godot/src/util/func_godot_texture_loader.gd
+++ b/addons/func_godot/src/util/func_godot_texture_loader.gd
@@ -144,6 +144,7 @@ func create_material(texture_name: String) -> Material:
 	if (map_settings.save_generated_materials and material 
 		and texture_name != map_settings.clip_texture 
 		and texture_name != map_settings.skip_texture 
+		and texture_name != map_settings.origin_texture 
 		and texture.resource_path != "res://addons/func_godot/textures/default_texture.png"):
 		ResourceSaver.save(material, material_path)
 	


### PR DESCRIPTION
Texture Loader does not create materials for Skip or Clip textures, as the mesh faces using those textures are removed on build. Origin brushes have their faces removed as well, but the texture is still generated.

This PR changes that by adding an exception for the Origin texture alongside Skip and Clip as intended.