### PR TITLE
Change export_func_godot_settings and reload_func_godot_settings to tool buttons

### DIFF
--- a/addons/func_godot/func_godot_local_config.tres
+++ b/addons/func_godot/func_godot_local_config.tres
@@ -4,4 +4,3 @@
 
 [resource]
 script = ExtResource("1_g8kqj")
-export_func_godot_settings = false

--- a/addons/func_godot/src/util/func_godot_local_config.gd
+++ b/addons/func_godot/src/util/func_godot_local_config.gd
@@ -15,10 +15,8 @@ enum PROPERTY {
 	DEFAULT_INVERSE_SCALE
 }
 
-@export var export_func_godot_settings: bool: set = _save_settings
-@export var reload_func_godot_settings: bool = false :
-	set(value):
-		_load_settings()
+@export_tool_button("Export func_godot settings", "Save") var export_func_godot_settings = _save_settings
+@export_tool_button("Reload func_godot settings", "Reload") var reload_func_godot_settings = _load_settings
 
 const CONFIG_PROPERTIES: Array[Dictionary] = [
 	{


### PR DESCRIPTION
This PR changes "Export Func Godot Settings" and "Reload Func Godot Settings" from checkboxes to buttons.

It's not very intuitive that checking a checkbox would do some action, but it's more obvious with buttons.

![image](https://github.com/user-attachments/assets/acc3a9ef-28c2-45e2-b7fc-c05c3bdd4da6)
