### PR TITLE
Verify Project Settings and Use Correct Setter for Default Map Settings

### DIFF
--- a/addons/func_godot/src/func_godot_plugin.gd
+++ b/addons/func_godot/src/func_godot_plugin.gd
@@ -47,15 +47,17 @@ func _enter_tree() -> void:
 	
 	add_custom_type("FuncGodotMap", "Node3D", preload("res://addons/func_godot/src/map/func_godot_map.gd"), null)
 	
-	ProjectSettings.set("func_godot/default_map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
-	var property_info = {
-		"name": "func_godot/default_map_settings",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_FILE,
-		"hint_string": "*.tres"
-	}
-	ProjectSettings.add_property_info(property_info)
-	ProjectSettings.set_initial_value("func_godot/default_map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
+	if not ProjectSettings.has_setting("func_godot/default_map_settings"):
+		ProjectSettings.set_setting("func_godot/default_map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
+		var property_info = {
+			"name": "func_godot/default_map_settings",
+			"type": TYPE_STRING,
+			"hint": PROPERTY_HINT_FILE,
+			"hint_string": "*.tres"
+		}
+		ProjectSettings.add_property_info(property_info)
+		ProjectSettings.set_as_basic("func_godot/default_map_settings", true)
+		ProjectSettings.set_initial_value("func_godot/default_map_settings", "res://addons/func_godot/func_godot_default_map_settings.tres")
 
 func _exit_tree() -> void:
 	remove_custom_type("FuncGodotMap")


### PR DESCRIPTION
Changed `ProjectSettings.set("func_godot/default_map_settings", ...)` to `ProjectSettings.set_setting("func_godot/default_map_settings", ...)` as that should be the correct function to call when adding a setting.

Also adds a verification that the setting does not already exist in order to avoid overwriting custom changes.

Also sets the setting to basic explicitly, making sure that it's always available to users.

Should resolve #106 