### PR TITLE
prevent unwrapping UVs on children of ModelPoint entite scenes

### DIFF
--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -269,7 +269,7 @@ func unwrap_uv2(node: Node = null) -> void:
 		print("Unwrapping mesh UV2s")
 	
 	if target_node is MeshInstance3D:
-		if target_node.gi_mode == GeometryInstance3D.GI_MODE_STATIC:
+		if target_node.gi_mode == GeometryInstance3D.GI_MODE_STATIC and target_node.owner == owner:
 			var mesh: Mesh = target_node.get_mesh()
 			if mesh is ArrayMesh:
 				mesh.lightmap_unwrap(Transform3D.IDENTITY, map_settings.uv_unwrap_texel_size * map_settings.scale_factor)


### PR DESCRIPTION
We shouldn't unwrap the UVs of MeshInstances of ModelPoint Entities. It ends up breaking lightmapping unless you do a really weird specific unwrap -> reload project -> bake sequence.

Should resolve #128 