### PR TITLE
Minor additional safety check for scene tree in the entity assembler

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -391,7 +391,12 @@ func generate_entity_node(entity_data: _EntityData, entity_index: int) -> Node:
 ## Main entity assembly process called by [FuncGodotMap]. Generates and sorts group nodes in the [SceneTree] first, 
 ## then generates and assembles [Node]s based upon the provided [FuncGodotData.EntityData] and adds them to the [SceneTree].
 func build(map_node: FuncGodotMap, entities: Array[_EntityData], groups: Array[_GroupData]) -> void:
-	var scene_root := map_node.get_tree().edited_scene_root
+	var scene_tree := map_node.get_tree();
+	var scene_root: Node;
+	if scene_tree:
+		scene_root = scene_tree.edited_scene_root;
+	else:
+		scene_root = map_node;
 	build_flags = map_node.build_flags
 	
 	if map_settings.use_groups_hierarchy:

--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -391,12 +391,7 @@ func generate_entity_node(entity_data: _EntityData, entity_index: int) -> Node:
 ## Main entity assembly process called by [FuncGodotMap]. Generates and sorts group nodes in the [SceneTree] first, 
 ## then generates and assembles [Node]s based upon the provided [FuncGodotData.EntityData] and adds them to the [SceneTree].
 func build(map_node: FuncGodotMap, entities: Array[_EntityData], groups: Array[_GroupData]) -> void:
-	var scene_tree := map_node.get_tree();
-	var scene_root: Node;
-	if scene_tree:
-		scene_root = scene_tree.edited_scene_root;
-	else:
-		scene_root = map_node;
+	var scene_root := map_node.get_tree().edited_scene_root if map_node.get_tree() else map_node;
 	build_flags = map_node.build_flags
 	
 	if map_settings.use_groups_hierarchy:


### PR DESCRIPTION
Hi, as I'm updating func_godot_scene_import to the latest version, I've run into a small hitch. When importing, the node is not part of the scene tree so get_tree() returns null, and the map fails to build. I don't know when else a scene might not be a part of a scene tree, but this adds a safety check for those circumstances

This is a small safety check, that checks if the map node is part of a scene tree, if it is, it uses that scene root, and if not, it uses itself.