### PR TITLE
Bug fixes for mesh metadata generation

### DIFF
--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -381,12 +381,26 @@ func generate_entity_surfaces(entity_index: int) -> void:
 				continue
 
 			# Handle metadata for this face
+			# Add metadata per triangle rather than per face to keep consistent metadata
+			var num_tris = face.indices.size() / 3
 			if def.add_textures_metadata:
-				textures_metadata.append(tex_index)
+				var tex_array : Array[int] = []
+				tex_array.resize(num_tris)
+				tex_array.fill(tex_index)
+				textures_metadata.append_array(tex_array)
 			if def.add_face_normal_metadata:
-				normals_metadata.append(FuncGodotUtil.id_to_opengl(face.plane.normal))
+				var normal_array : Array[Vector3] = []
+				normal_array.resize(num_tris)
+				normal_array.fill(FuncGodotUtil.id_to_opengl(face.plane.normal))
+				normals_metadata.append_array(normal_array)
 			if def.add_face_position_metadata:
-				positions_metadata.append(face.get_centroid())
+				for i in num_tris:
+					var triangle_indices : Array[int] = []
+					var triangle_vertices : Array[Vector3] = []
+					triangle_indices.assign(face.indices.slice(i * 3, i * 3 + 3))
+					triangle_vertices.assign(triangle_indices.map(func(idx : int) -> Vector3: return face.vertices[idx]))
+					var position := FuncGodotUtil.op_vec3_avg(triangle_vertices);
+					positions_metadata.append(op_entity_ogl_xf.call(position))
 			if def.add_vertex_metadata:
 				for i in face.indices:
 					vertices_metadata.append(op_entity_ogl_xf.call(face.vertices[i]))


### PR DESCRIPTION
- Move texture metadata to the mesh building loop to keep all metadata logic in the same place
- Change normals metadata to face normals, rather than vertex normals from the mesh builder
- Use the existing get_centroid function to calculate face positions
- Add vertices using the triangle indices rather than the vertex array from the mesh builder
- Also a tiny whitespace fix on the comments at the end - they were indented too much

To test this I made a simple map with 5 visible quads using 4 different textures. Expectation is  that texture_names has 4 entries, textures/normals/positions all have 5, and vertices has 30 (5 quads -> 10 tris -> 30 verts).

Before:
<img width="556" height="247" alt="image" src="https://github.com/user-attachments/assets/b0310fb6-208a-4f0f-aa8b-8a95218f7c64" />

After:
<img width="554" height="239" alt="image" src="https://github.com/user-attachments/assets/caa1d663-0ee7-453e-94e6-38ef4f107e19" />

