### PR TITLE
Fix for string default values in 'choices' properties

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -131,7 +131,7 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 			if value is Dictionary and class_property_descriptions[prop] is Array:
 				var prop_arr: Array = class_property_descriptions[prop]
 				if prop_arr.size() > 1 and (prop_arr[1] is int or prop_arr[1] is String):
-					prop_description = "\"" + prop_arr[0] + "\" : " + str(prop_arr[1])
+					prop_description = "\"" + prop_arr[0] + "\" : \"" + str(prop_arr[1]) + "\""
 				else:
 					prop_description = "\"\" : 0"
 					printerr(str(prop) + " has incorrect description format. Should be [String description, int / String default value].")

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -131,7 +131,8 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 			if value is Dictionary and class_property_descriptions[prop] is Array:
 				var prop_arr: Array = class_property_descriptions[prop]
 				if prop_arr.size() > 1 and (prop_arr[1] is int or prop_arr[1] is String):
-					prop_description = "\"" + prop_arr[0] + "\" : \"" + str(prop_arr[1]) + "\""
+					var value_str : String = str(prop_arr[1]) if prop_arr[1] is int else "\"" + prop_arr[1] + "\""
+					prop_description = "\"" + prop_arr[0] + "\" : " + value_str
 				else:
 					prop_description = "\"\" : 0"
 					printerr(str(prop) + " has incorrect description format. Should be [String description, int / String default value].")


### PR DESCRIPTION
The documentation and code allows both String and int types as values for choices properties, however when exporting the FGD the value is not quoted, causing parsing errors when the value is of string type.

The fix just quotes the value, which works for both string and int types.