### PR TITLE
Export bool property defaults to FGD

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -215,7 +215,9 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 					res += " : "
 					res += prop_description
 			
-			if value is bool or value is Dictionary or value is Array:
+			if value is bool:
+				res += " : 1 = " if value else " : 0 = "
+			elif value is Dictionary or value is Array:
 				res += " = "
 			else:
 				res += " : "


### PR DESCRIPTION
Default values for boolean properties are fully supported, but their default value is not added to the FGD so it is not visible in the editor.

This change would update the FGD from:

```
name(choices) : "description" = 
[
	0 : "No"
	1 : "Yes"
]
```

to:

```
name(choices) : "description" : 1 = 
[
	0 : "No"
	1 : "Yes"
]
```