### PR TITLE
Fix issues when loading materials without albedo textures

### DIFF
--- a/addons/func_godot/src/util/func_godot_util.gd
+++ b/addons/func_godot/src/util/func_godot_util.gd
@@ -191,7 +191,9 @@ static func build_texture_map(entity_data: Array[FuncGodotData.EntityData], map_
 					var material: Material = load(material_path)
 					texture_materials[texture_name] = material
 					if material is BaseMaterial3D:
-						texture_sizes[texture_name] = material.albedo_texture.get_size()
+						var albedo = material.albedo_texture
+						if albedo is Texture2D:
+							texture_sizes[texture_name] = material.albedo_texture.get_size()
 					elif material is ShaderMaterial:
 						var albedo = material.get_shader_parameter(map_settings.default_material_albedo_uniform)
 						if albedo is Texture2D:


### PR DESCRIPTION
For my game I have a few materials that have no albedo texture at all.

Right now, func_godot will crash while trying to load them, because `material.albedo_texture` will be `null`.

This change fixes this issue.