### PR TITLE
Add check for clip brushes to generate_entity_surfaces

### DIFF
--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -359,7 +359,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 	# Arrange faces by surface texture
 	for brush in entity.brushes:
 		for face in brush.faces:
-			if is_skip(face) or is_origin(face):
+			if is_skip(face) or is_origin(face) or is_clip(face):
 				continue
 			
 			if not surfaces.has(face.texture):


### PR DESCRIPTION
Right now, any map that has `special/clip` will crash with error `res://addons/func_godot/src/core/geometry_generator.gd:478 - Invalid access to property or key 'special/clip' on a base object of type 'Dictionary[String, Material]'.`

With this change, `special/clip` should no longer get added to `textures_metadata`.