### PR TITLE
Resolve UID path in verify()

### DIFF
--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -65,6 +65,14 @@ func verify() -> Error:
 		fail_build("Cannot build empty map file.")
 		return ERR_INVALID_PARAMETER
 	
+	# Retrieve real path if needed
+	if _map_file_internal.begins_with("uid://"):
+		var uid := ResourceUID.text_to_id(_map_file_internal)
+		if not ResourceUID.has_id(uid):
+			fail_build("Error: failed to retrieve path for UID (%s)" % _map_file_internal)
+			return ERR_DOES_NOT_EXIST
+		_map_file_internal = ResourceUID.get_id_path(uid)
+	
 	if not FileAccess.file_exists(_map_file_internal):
 		if not FileAccess.file_exists(_map_file_internal + ".import"):
 			fail_build("Map file %s does not exist." % _map_file_internal)


### PR DESCRIPTION
Right now, if your game passes map file to FuncGodotMap by UID, during building it will crash with errors

```
ERROR: Invalid UID.
   at: (core/io/resource_uid.cpp:154)
ERROR: [MAP] Map file uid://SOMEUID does not exist.
   at: push_error (core/variant/variant_utility.cpp:1098)
ERROR: [MAP] Verification failed: Does not exist. Aborting map build
   at: push_error (core/variant/variant_utility.cpp:1098)
```

Resolving UID to path in `verify()` resolves this issue.

Personally I'm not even sure why is `verify()` needed, considering `parse_map_data()` in `parser.gd` already verifies itself that everything is correct and map file exists.