### PR TITLE
Implement the collision shape to face indices map metadata

### DIFF
--- a/addons/func_godot/fgd/func_detail.tres
+++ b/addons/func_godot/fgd/func_detail.tres
@@ -22,6 +22,7 @@ add_textures_metadata = false
 add_vertex_metadata = false
 add_face_position_metadata = false
 add_face_normal_metadata = false
+add_collision_shape_to_face_indices_metadata = false
 add_collision_shape_face_range_metadata = false
 classname = "func_detail"
 description = "Static collidable geometry. Builds a StaticBody3D with a MeshInstance3D and a single concave CollisionShape3D. Does not occlude other VisualInstance3D nodes."

--- a/addons/func_godot/fgd/func_detail_illusionary.tres
+++ b/addons/func_godot/fgd/func_detail_illusionary.tres
@@ -22,6 +22,7 @@ add_textures_metadata = false
 add_vertex_metadata = false
 add_face_position_metadata = false
 add_face_normal_metadata = false
+add_collision_shape_to_face_indices_metadata = false
 add_collision_shape_face_range_metadata = false
 classname = "func_detail_illusionary"
 description = "Static geometry with no collision. Builds a Node3D with a MeshInstance3D. Does not occlude other VisualInstance3D nodes."

--- a/addons/func_godot/fgd/func_geo.tres
+++ b/addons/func_godot/fgd/func_geo.tres
@@ -22,6 +22,7 @@ add_textures_metadata = false
 add_vertex_metadata = false
 add_face_position_metadata = false
 add_face_normal_metadata = false
+add_collision_shape_to_face_indices_metadata = false
 add_collision_shape_face_range_metadata = false
 classname = "func_geo"
 description = "Static collidable geometry. Builds a StaticBody3D with a MeshInstance3D, a single concave CollisionShape3D, and an OccluderInstance3D."

--- a/addons/func_godot/fgd/func_illusionary.tres
+++ b/addons/func_godot/fgd/func_illusionary.tres
@@ -22,6 +22,7 @@ add_textures_metadata = false
 add_vertex_metadata = false
 add_face_position_metadata = false
 add_face_normal_metadata = false
+add_collision_shape_to_face_indices_metadata = false
 add_collision_shape_face_range_metadata = false
 classname = "func_illusionary"
 description = "Static geometry with no collision. Builds a Node3D with a MeshInstance3D and an Occluder3D to aid in render culling of other VisualInstance3D nodes."

--- a/addons/func_godot/fgd/worldspawn.tres
+++ b/addons/func_godot/fgd/worldspawn.tres
@@ -21,6 +21,7 @@ add_textures_metadata = false
 add_vertex_metadata = false
 add_face_position_metadata = false
 add_face_normal_metadata = false
+add_collision_shape_to_face_indices_metadata = false
 add_collision_shape_face_range_metadata = false
 classname = "worldspawn"
 description = "Default static world geometry. Builds a StaticBody3D with a single MeshInstance3D and a single convex CollisionShape3D shape. Also builds Occluder3D to aid in render culling of other VisualInstance3D nodes."

--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -126,7 +126,7 @@ func generate_solid_entity_node(node: Node, node_name: String, data: _EntityData
 			if shape_to_face_array.size() > i:
 				face_index_metadata[collision_shape.name] = shape_to_face_array[i]
 		
-		if definition.add_collision_shape_face_range_metadata:
+		if definition.add_collision_shape_to_face_indices_metadata:
 			data.mesh_metadata['collision_shape_to_face_indices_map'] = face_index_metadata
 
 	if "position" in node:

--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -409,7 +409,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 			if def.add_vertex_metadata:
 				for i in face.indices:
 					vertices_metadata.append(op_entity_ogl_xf.call(face.vertices[i]))
-			if def.add_collision_shape_face_range_metadata:
+			if def.add_collision_shape_to_face_indices_metadata:
 				face_index_metadata_map[face] = PackedInt32Array(range(current_metadata_index, current_metadata_index + num_tris))
 			current_metadata_index += num_tris
 			
@@ -481,7 +481,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 			sh.points = points
 			entity.shapes.append(sh)
 	
-			if def.add_collision_shape_face_range_metadata:
+			if def.add_collision_shape_to_face_indices_metadata:
 				# convex collision has one shape per brush, so collect the
 				# indices for this brush's faces
 				var face_indices_array : PackedInt32Array = []
@@ -495,7 +495,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 		sh.set_faces(concave_vertices)
 		entity.shapes.append(sh)
 		
-		if def.add_collision_shape_face_range_metadata:
+		if def.add_collision_shape_to_face_indices_metadata:
 			# for concave collision the shape will always represent every face
 			# in the entity, so just add every face here
 			var face_indices_array : PackedInt32Array = []
@@ -503,7 +503,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 				face_indices_array.append_array(fm)
 			shape_to_face_metadata.append(face_indices_array)
 			
-	if def.add_collision_shape_face_range_metadata:
+	if def.add_collision_shape_to_face_indices_metadata:
 		# this metadata will be mapped to the actual shape node names during entity assembly
 		entity.mesh_metadata["shape_to_face_array"] = shape_to_face_metadata
 

--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -308,11 +308,14 @@ func generate_entity_surfaces(entity_index: int) -> void:
 	var surfaces: Dictionary[String, Array] = {}
 
 	# Metadata
+	var current_metadata_index: int = 0
 	var texture_names_metadata: Array[StringName] = []
 	var textures_metadata: PackedInt32Array = []
 	var vertices_metadata: PackedVector3Array = []
 	var normals_metadata: PackedVector3Array = []
 	var positions_metadata: PackedVector3Array = []
+	var shape_to_face_metadata: Array[PackedInt32Array] = []
+	var face_index_metadata_map: Dictionary[_FaceData, PackedInt32Array] = {}
 	
 	# Arrange faces by surface texture
 	for brush in entity.brushes:
@@ -406,6 +409,9 @@ func generate_entity_surfaces(entity_index: int) -> void:
 			if def.add_vertex_metadata:
 				for i in face.indices:
 					vertices_metadata.append(op_entity_ogl_xf.call(face.vertices[i]))
+			if def.add_collision_shape_face_range_metadata:
+				face_index_metadata_map[face] = PackedInt32Array(range(current_metadata_index, current_metadata_index + num_tris))
+			current_metadata_index += num_tris
 			
 			# Append face data to surface array
 			for i in face.vertices.size():
@@ -475,10 +481,31 @@ func generate_entity_surfaces(entity_index: int) -> void:
 			sh.points = points
 			entity.shapes.append(sh)
 	
+			if def.add_collision_shape_face_range_metadata:
+				# convex collision has one shape per brush, so collect the
+				# indices for this brush's faces
+				var face_indices_array : PackedInt32Array = []
+				for face in b.faces:
+					if face_index_metadata_map.has(face):
+						face_indices_array.append_array(face_index_metadata_map[face])
+				shape_to_face_metadata.append(face_indices_array)
+
 	elif build_concave and concave_vertices.size():
 		var sh := ConcavePolygonShape3D.new()
 		sh.set_faces(concave_vertices)
 		entity.shapes.append(sh)
+		
+		if def.add_collision_shape_face_range_metadata:
+			# for concave collision the shape will always represent every face
+			# in the entity, so just add every face here
+			var face_indices_array : PackedInt32Array = []
+			for fm in face_index_metadata_map.values():
+				face_indices_array.append_array(fm)
+			shape_to_face_metadata.append(face_indices_array)
+			
+	if def.add_collision_shape_face_range_metadata:
+		# this metadata will be mapped to the actual shape node names during entity assembly
+		entity.mesh_metadata["shape_to_face_array"] = shape_to_face_metadata
 
 func unwrap_uv2s(entity_index: int, texel_size: float) -> void:
 	var entity: _EntityData = entity_data[entity_index]

--- a/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
@@ -81,6 +81,13 @@ enum CollisionShapeType {
 ## Add a [PackedVector3Array] called [i]"normals"[/i] to the generated node's metadata on build.[br][br] 
 ## Contains a list of each face's normal.
 @export var add_face_normal_metadata: bool = false
+## Add a [Dictionary] called [i]"collision_shape_to_face_indices_map"[/i] in the generated node's metadata on build.[br][br] 
+## Contains keys of strings, which are the names of child [CollisionShape3D] nodes, and values of
+## [PackedInt32Array], containing indices of that child's faces.[br][br]
+## For example, an element of [br][br][code]{ "entity_1_brush_0_collision_shape" : [0, 1, 3] }[/code][br][br]
+## shows that this solid class has been generated with one child collision shape named 
+## [i]entity_1_brush_0_collision_shape[/i] which handles 3 faces of the mesh with collision, at indices 0, 1, and 3.
+@export var add_collision_shape_to_face_indices_metadata : bool = false
 ## [s]Add a [Dictionary] called [i]"collision_shape_to_face_range_map"[/i] in the generated node's metadata on build.[br][br] 
 ## Contains keys of strings, which are the names of child [CollisionShape3D] nodes, and values of
 ## [Vector2i], where [i]X[/i] represents the starting index of that child's faces and [i]Y[/i] represents the


### PR DESCRIPTION
This re-implements the functionality of the `collision_shape_to_face_range_map` metadata. Since the faces for each brush are no longer contiguous within a mesh, I've changed the metadata type from a range to a list of indices, and also changed the name of the metadata key to match. The configuration variable name should probably be updated to suit the change in data type.

## Geometry generator
For each face, I store a dictionary to map faces to the list of metadata indices for each triangle of the face. Then, when the collision shapes are generated:

- Convex shapes: when creating the collision shape for a brush, we loop through each face of and collect the metadata indices associated with that brush
- Concave shapes: only one shape is generated per entity, so we can simply collect the whole list of metadata indices associated with the entity (This means the resulting metadata will simply be an array from 0 to num_tris in the mesh, making this metadata type of little use when using concave collision. However, it is implemented here for consistency across both collision types.)

Either way, the data is stored in the `mesh_metadata` to be transformed in the next step.

## Entity assembler
Here I merged the shape creation into a single loop instead of the similar branches based on the concave/convex setting - now it just changes the node name based on the setting but otherwise uses the same logic. An immediate benefit is consistency - for the concave case, it was setting the `owner`, but it wasn't for the convex case. (I assume owner should be set in both scenarios, but let me know if that's wrong)

The other additions simply collects the metadata into a single object, and then attaches the metadata to the entity node.

## Questions
- I've changed the metadata name from `collision_shape_to_face_range_map` to `collision_shape_to_face_indices_map`, is this name fine or should I change it to something else?
- I haven't changed the user-facing `FuncGodotFGDSolidClass` property `add_collision_shape_face_range_metadata` in this PR. Should it get changed at the same time to something more accurate now that the data has changed from a range of indices to a list of indices?