### PR TITLE
Fixed loading of textures with spaces in their paths

### DIFF
--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -215,9 +215,12 @@ func _parse_quake_map(map_data: PackedStringArray, map_settings: FuncGodotMapSet
 			# Retrieve texture data
 			var tex: String = String()
 			if tokens[3].begins_with("\""): # textures with spaces get surrounded by double quotes
-				tex = tokens[3].split("\"")[0]
+				var last_quote := tokens[3].rfind("\"")
+				tex = tokens[3].substr(1, last_quote - 1)
+				tokens = tokens[3].substr(last_quote + 2).split(" ] ")
 			else:
-				tex = tokens[3].split(" ")[0]
+				tex = tokens[3].get_slice(" ", 0)
+				tokens = tokens[3].trim_prefix(tex + " ").split(" ] ")
 			face.texture = tex
 			
 			# Check for origin brushes. Brushes must be completely textured with origin to be valid.
@@ -230,7 +233,6 @@ func _parse_quake_map(map_data: PackedStringArray, map_settings: FuncGodotMapSet
 			
 			# Retrieve UV data
 			var uv: Transform2D = Transform2D.IDENTITY
-			tokens = tokens[3].trim_prefix(tex + " ").split(" ] ")
 			
 			# Valve 220: texname [ ux uy ux offsetX ] [vx vy vz offsetY] rotation scaleX scaleY
 			if tokens.size() > 1:


### PR DESCRIPTION
My texture has spaces in its name, so the brush in the map file is like this:

```
// brush 0
{
( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) "128x128/Bricks/Brick 1 - 128x128" [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) "128x128/Bricks/Brick 1 - 128x128" [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) "128x128/Bricks/Brick 1 - 128x128" [ -1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) "128x128/Bricks/Brick 1 - 128x128" [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) "128x128/Bricks/Brick 1 - 128x128" [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) "128x128/Bricks/Brick 1 - 128x128" [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
}
```

The texture failed to load because `[0]` is used after spliting, which is always empty :stuck_out_tongue: 

https://github.com/func-godot/func_godot_plugin/blob/28e468011ad66918b33d42415ef318b0a0bfd7df/addons/func_godot/src/core/parser.gd#L217-L221

Subsequent parsing of UV data also did not consider cases where the texture path is quoted.

I also changed the `.split(" ")[0]` in the normal branch into `.get_slice(" ", 0)` which is more performant.