### PR TITLE
Fix error when exporting FGD before exporting game config

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_file.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_file.gd
@@ -31,11 +31,20 @@ func do_export_file(target_editor: FuncGodotTargetMapEditors = FuncGodotTargetMa
 
 	if fgd_name == "":
 		print("Skipping export: Empty FGD name")
+	
+	if not DirAccess.dir_exists_absolute(fgd_output_folder):
+		if DirAccess.make_dir_recursive_absolute(fgd_output_folder) != OK:
+			print("Skipping export: Failed to create directory")
+			return
 
-	var fgd_file = fgd_output_folder + "/" + fgd_name + ".fgd"
-
-	print("Exporting FGD to ", fgd_file)
+	var fgd_file = fgd_output_folder.path_join(fgd_name + ".fgd")
+	
 	var file_obj := FileAccess.open(fgd_file, FileAccess.WRITE)
+	if not file_obj:
+		print("Failed to open file for writing: ", fgd_file)
+		return
+	
+	print("Exporting FGD to ", fgd_file)
 	file_obj.store_string(build_class_text(target_editor))
 	file_obj.close()
 


### PR DESCRIPTION
I get an error when clicking the Export FGD button for FuncGodotFGDFile. It works fine after clicking Export GameConfig for TrenchBroomGameConfig.

> res://addons/func_godot/src/fgd/func_godot_fgd_file.gd:39 - Cannot call method 'store_string' on a null value.

I was following [this tutorial](https://youtu.be/_FFYBkMka60?t=515) created a year ago and the author had the same error.

It turns out that we are both entering the path manually instead of creating and picking the output directory via the file dialog. Export GameConfig automatically creates the FGD output directory when the directory is missing, whereas Export FGD does not. This PR adds the missing logic.

I also changed manual path concatenation to `path_join()` so it works better when `fgd_output_folder` contains a trailing slash.

https://github.com/func-godot/func_godot_plugin/blob/d1a4cf8538c93e96dc837a5d9b377b4a8882f44b/addons/func_godot/src/fgd/func_godot_fgd_file.gd#L35