### PR TITLE
Fix error on first map import

### DIFF
--- a/addons/func_godot/src/import/quake_map_import_plugin.gd
+++ b/addons/func_godot/src/import/quake_map_import_plugin.gd
@@ -33,9 +33,8 @@ func _import(source_file, save_path, options, r_platform_variants, r_gen_files) 
 
 	var map_resource : QuakeMapFile = null
 
-	var existing_resource := load(save_path_str) as QuakeMapFile
-	if(existing_resource != null):
-		map_resource = existing_resource
+	if ResourceLoader.exists(save_path_str):
+		map_resource = load(save_path_str) as QuakeMapFile
 		map_resource.revision += 1
 	else:
 		map_resource = QuakeMapFile.new()


### PR DESCRIPTION
There is always an error when the editor sees a `*.map` file for the first time:

> ERROR: Cannot open file 'res://.godot/imported/test.map-75dfd93010aa3e622384aaaff66cbb14.tres'.
> ERROR: Failed loading resource: res://.godot/imported/test.map-75dfd93010aa3e622384aaaff66cbb14.tres. Make sure resources have been imported by opening the project in the editor at least once.

This is because the imported resource does not exist yet. So the `load()` call complains about that.

https://github.com/func-godot/func_godot_plugin/blob/93a812e1afa4bb41ec69c1d86c114f2a6c627e8d/addons/func_godot/src/import/quake_map_import_plugin.gd#L36-L41

We can use `ResourceLoader.exists()` to avoid that :smiley: 