### PR TITLE
Fix tangent array append index offset error, minor syntax cleanup

### DIFF
--- a/addons/func_godot/src/core/data.gd
+++ b/addons/func_godot/src/core/data.gd
@@ -166,7 +166,7 @@ class EntityData extends RefCounted:
 	## Determines if the entity's mesh should be processed for normal smoothing. 
 	## The smoothing property can be retrieved from [member FuncGodotMapSettings.entity_smoothing_property].
 	func is_smooth_shaded(smoothing_property: String = "_phong") -> bool: 
-		return properties.get(smoothing_property, "0").to_int();
+		return properties.get(smoothing_property, "0").to_int()
   	
 	## Retrieves the entity's smoothing angle to determine if the face should be smoothed. 
 	## The smoothing angle property can be retrieved from [member FuncGodotMapSettings.entity_smoothing_angle_property].

--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -57,7 +57,7 @@ func generate_solid_entity_node(node: Node, node_name: String, data: _EntityData
 		node = Node3D.new()
 	
 	node.name = node_name
-	node_name = node_name.trim_suffix(definition.classname).trim_suffix("_");
+	node_name = node_name.trim_suffix(definition.classname).trim_suffix("_")
 	var properties: Dictionary = data.properties
 	
 	# Mesh Instance generation

--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -10,14 +10,14 @@ const _VERTEX_EPSILON2 	:= _VERTEX_EPSILON * _VERTEX_EPSILON
 
 const _HYPERPLANE_SIZE	:= 65355.0
 
-const _OriginType 	:= FuncGodotFGDSolidClass.OriginType;
+const _OriginType 	:= FuncGodotFGDSolidClass.OriginType
 
 const _GroupData		:= FuncGodotData.GroupData
 const _EntityData 		:= FuncGodotData.EntityData
 const _BrushData 		:= FuncGodotData.BrushData
 const _PatchData 		:= FuncGodotData.PatchData
 const _FaceData 		:= FuncGodotData.FaceData
-const _VertexGroupData	:= FuncGodotData.VertexGroupData;
+const _VertexGroupData	:= FuncGodotData.VertexGroupData
 
 # Class members
 var map_settings: FuncGodotMapSettings = null
@@ -135,9 +135,13 @@ func generate_brush_vertices(entity_index: int, brush_index: int) -> void:
 		face.normals.fill(face.plane.normal)
 
 		var tangent: PackedFloat32Array = FuncGodotUtil.get_face_tangent(face)
-
+	
+		# convert into OpenGL coordinates
 		for i in face.vertices.size():
-			face.tangents.append_array(tangent)
+			face.tangents.append(tangent[1]) # Y
+			face.tangents.append(tangent[2]) # Z
+			face.tangents.append(tangent[0]) # X
+			face.tangents.append(tangent[3]) # W
 	return
 
 func generate_entity_vertices(entity_index: int) -> void:
@@ -223,6 +227,7 @@ func wind_entity_faces(entity_index: int) -> void:
 	var entity: _EntityData = entity_data[entity_index]
 	for brush in entity.brushes:
 		for face in brush.faces:
+			# Faces should already be wound from the new generation process, but this should be tested further first.
 			face.wind()
 			face.index_vertices()
 
@@ -248,7 +253,7 @@ func smooth_entity_vertices(entity_index: int) -> void:
 				data.faces.append(face)
 				data.face_indices.append(i)
 	
-	var smoothed_normals: PackedVector3Array;
+	var smoothed_normals: PackedVector3Array
 	
 	for vertex_group in vertex_map.values():
 		if vertex_group.faces.size() <= 1:
@@ -325,7 +330,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 			surfaces[face.texture].append(face)
 	
 	# Cache order for consistency when rebuilding 
-	var textures: Array[String] = surfaces.keys();
+	var textures: Array[String] = surfaces.keys()
 	
 	# Output mesh data
 	var mesh := ArrayMesh.new()
@@ -368,7 +373,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 			
 			# Create trimesh points regardless of texture
 			if build_concave:
-				var tris: PackedVector3Array;
+				var tris: PackedVector3Array
 				tris.resize(face.indices.size())
 				
 				# Add triangles from face indices directly
@@ -401,7 +406,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 					var triangle_vertices: Array[Vector3] = []
 					triangle_indices.assign(face.indices.slice(i * 3, i * 3 + 3))
 					triangle_vertices.assign(triangle_indices.map(func(idx : int) -> Vector3: return face.vertices[idx]))
-					var position := FuncGodotUtil.op_vec3_avg(triangle_vertices);
+					var position := FuncGodotUtil.op_vec3_avg(triangle_vertices)
 					positions_metadata.append(op_entity_ogl_xf.call(position))
 			if def.add_vertex_metadata:
 				for i in face.indices:
@@ -417,7 +422,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 				arrays[ArrayMesh.ARRAY_TEX_UV].append(FuncGodotUtil.get_face_vertex_uv(v, face, tx_sz))
 				
 				for j in 4:
-					arrays[ArrayMesh.ARRAY_TANGENT].append(face.tangents[i + j])
+					arrays[ArrayMesh.ARRAY_TANGENT].append(face.tangents[(i * 4) + j])
 			
 			# Create offset indices for the visual mesh
 			var op_shift_index: Callable = (func(a: int) -> int: return a + index_offset)
@@ -462,7 +467,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 	surfaces = {}
 	
 	if entity.is_collision_convex():
-		var sh: ConvexPolygonShape3D;
+		var sh: ConvexPolygonShape3D
 		for b in entity.brushes:
 			if b.planes.is_empty() or b.origin:
 				continue

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -91,10 +91,10 @@ func build() -> void:
 
 	clear_children()
 	
-	var verify_err: Error = verify();
+	var verify_err: Error = verify()
 	if verify_err != OK:
 		fail_build("Verification failed: %s. Aborting map build" % error_string(verify_err), true)
-		return;
+		return
 	
 	if not map_settings:
 		push_warning("Map assembler does not have a map settings provided and will use default map settings.")
@@ -126,7 +126,7 @@ func build() -> void:
 	var generate_error := generator.build(build_flags, entities)
 	if generate_error != OK:
 		fail_build("Geometry generation failed: %s" % error_string(generate_error))
-		return;
+		return
 
 	# Assemble entities and groups
 	var assembler := FuncGodotEntityAssembler.new(map_settings)

--- a/addons/func_godot/src/netradiant_custom/netradiant_custom_gamepack_config.gd
+++ b/addons/func_godot/src/netradiant_custom/netradiant_custom_gamepack_config.gd
@@ -10,7 +10,7 @@ enum NetRadiantCustomMapType {
 	QUAKE_3 ## Allows the saving of PatchDef entries in the map file.
 }
 
-@export_tool_button("Export Gamepack") var _export_file: Callable = export_file; 
+@export_tool_button("Export Gamepack") var _export_file: Callable = export_file 
 
 ## Gamepack folder and file name. Must be lower case and must not contain special characters.
 @export var gamepack_name : String = "func_godot":

--- a/addons/func_godot/src/util/func_godot_util.gd
+++ b/addons/func_godot/src/util/func_godot_util.gd
@@ -1,7 +1,7 @@
 class_name FuncGodotUtil
 ## Static class with a number of reuseable utility methods that can be called at Editor or Run Time.
 
-const _VERTEX_EPSILON: float = 0.008;
+const _VERTEX_EPSILON: float = 0.008
 
 const _VEC3_UP_ID		:= Vector3(0.0, 0.0, 1.0)
 const _VEC3_RIGHT_ID		:= Vector3(0.0, 1.0, 0.0)
@@ -29,14 +29,6 @@ static func op_vec3_avg(array: Array[Vector3]) -> Vector3:
 		push_error("Cannot average empty Vector3 array!")
 		return Vector3()
 	return array.reduce(op_vec3_sum, Vector3()) / array.size()
-
-static func op_swizzle_vec3_w(xyz: Vector3, w: float) -> PackedFloat32Array:
-	var out := PackedFloat32Array()
-	out.resize(4)
-	for i in 3:
-		out[i] = xyz[i]
-	out[3] = w
-	return out
 
 ## Conversion from id tech coordinate system to Godot, from a top-down perspective.
 static func id_to_opengl(vec: Vector3) -> Vector3: 
@@ -132,8 +124,8 @@ static func filter_face(texture: String, map_settings: FuncGodotMapSettings) -> 
 			or texture == map_settings.clip_texture
 		 	or texture == map_settings.origin_texture
 			):
-			return true;
-	return false;
+			return true
+	return false
 
 ## Adds PBR textures to an existing [BaseMaterial3D].
 static func build_base_material(map_settings: FuncGodotMapSettings, material: BaseMaterial3D, texture: String) -> void:
@@ -273,22 +265,24 @@ static func get_face_vertex_uv(vertex: Vector3, face: FuncGodotData.FaceData, te
 
 ## Returns the tangent calculated from the Valve 220 UV format.
 static func get_valve_tangent(u: Vector3, v: Vector3, normal: Vector3) -> PackedFloat32Array:
-	var tangent: Vector3 = u.normalized() 
-	tangent = (tangent - normal * normal.dot(tangent)).normalized()
-	
-	# in the case of parallel U or V axes to planar normal, reconstruct the tangent
-	if tangent.length_squared() < 0.01:
-		if absf(normal.y) < 0.9:
-			tangent = Vector3.UP.cross(normal)
-		else:
-			tangent = Vector3.RIGHT.cross(normal)
-	
-	tangent = tangent.normalized()
+	var u_axis: Vector3 = u.normalized()
+	var v_axis: Vector3 = v.normalized()
+	var v_sign: float = -signf(normal.cross(u_axis).dot(v_axis))
+	return [u_axis.x, u_axis.y, u_axis.z, v_sign]
 
-	return op_swizzle_vec3_w(
-		tangent,
-		signf(normal.cross(tangent).dot(v.normalized()))
-	)
+	# NOTE: we may still need to orthonormalize tangents. Just in case, here's a rough outline.
+	#var tangent: Vector3 = u.normalized() 
+	#tangent = (tangent - normal * normal.dot(tangent)).normalized()
+	#
+	## in the case of parallel U or V axes to planar normal, reconstruct the tangent
+	#if tangent.length_squared() < 0.01:
+	#	if absf(normal.y) < 0.9:
+	#		tangent = Vector3.UP.cross(normal)
+	#	else:
+	#		tangent = Vector3.RIGHT.cross(normal)
+	#
+	#tangent = tangent.normalized()
+	#return [tangent.x, tangent.y, tangent.z, -signf(normal.cross(tangent).dot(v.normalized))]
 
 ## Returns the tangent calculated from the original id Standard UV format.
 static func get_quake_tangent(normal: Vector3, uv_y_scale: float, uv_rotation: float) -> PackedFloat32Array:
@@ -313,7 +307,7 @@ static func get_quake_tangent(normal: Vector3, uv_y_scale: float, uv_rotation: f
 		
 	v_sign *= signf(uv_y_scale)
 	u_axis = u_axis.rotated(normal, deg_to_rad(-uv_rotation) * v_sign)
-	return op_swizzle_vec3_w(u_axis, v_sign)
+	return [u_axis.x, u_axis.y, u_axis.z, v_sign]
 
 static func get_face_tangent(face: FuncGodotData.FaceData) -> PackedFloat32Array:
 	if face.uv_axes.size() >= 2:


### PR DESCRIPTION
During the rewrite, a critical oversight was missed with using the valid tangent data in generate_surfaces:

`arrays[ArrayMesh.ARRAY_TANGENT].append(face.tangents[i + j])`

This resulted in tangent data being incorrectly built for each vertex when iterating through face.vertices.size().

The correction:

`arrays[ArrayMesh.ARRAY_TANGENT].append(face.tangents[(i * 4) + j])`

See below.

```
for i in 5:
	for j in 4:
		var o := i + j;
		var n := (i * 4) + j;
		if (o == n):
			prints("master == this_pr", o, n)
		else:
			prints("master != this_pr; master: %s - corrected: %s" % [o, n])

# output:
# master == this_pr 0 0
# master == this_pr 1 1
# master == this_pr 2 2
# master == this_pr 3 3
# master != this_pr; master: 1 - corrected: 4
# master != this_pr; master: 2 - corrected: 5
# master != this_pr; master: 3 - corrected: 6
# master != this_pr; master: 4 - corrected: 7
# master != this_pr; master: 2 - corrected: 8
# master != this_pr; master: 3 - corrected: 9
# master != this_pr; master: 4 - corrected: 10
# master != this_pr; master: 5 - corrected: 11
# master != this_pr; master: 3 - corrected: 12
# and so on...
```


https://github.com/user-attachments/assets/9299788c-b7b0-44b2-b570-294c3785bf76

