### PR TITLE
Output  `Dictionary` values for meta-properties as JSON-stringified represenations if targeting Trenchbroom

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -103,6 +103,8 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 			]
 		elif value is String:
 			res += value
+		elif value is Dictionary and target_editor == FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM:
+			res += JSON.stringify(value)
 		
 		res += ")"
 	


### PR DESCRIPTION
This is a small quality of life change that I made while using this project, and figured it might be useful or appreciated.

Specifically for the Trenchbroom `model` meta-property, the full syntax (i.e. not the shorthand that just uses a string) seems to be a JSON object. This change makes it so that it's a little easier to specify this property in a "Godot"-y way, i.e. with a `Dictionary` as the value of the meta-property definition. 

The default `JSON.stringify`  output seems to be cromulent enough JSON for Trenchbroom to parse, at least in my testing, without disrupting formatting.

Example definition:
<img width="358" height="294" alt="image" src="https://github.com/user-attachments/assets/352af6b3-22f7-49d8-9f64-5b601f268f4f" />

Example output:
<img width="1243" height="35" alt="image" src="https://github.com/user-attachments/assets/0e47d506-a06f-4162-8de0-ba21515b8f43" />

