### PR TITLE
Don't process for materials for brushes without visuals

### DIFF
--- a/addons/func_godot/src/core/data.gd
+++ b/addons/func_godot/src/core/data.gd
@@ -148,6 +148,12 @@ class EntityData extends RefCounted:
 	var occluder_instance: OccluderInstance3D = null
 	## True global position of the entity's generated node that the mesh's vertices are offset by during the geometry generation stage.
 	var origin: Vector3 = Vector3.ZERO
+
+	## Checks the entity's FGD resource definition, returning whether the Solid Class has a [MeshInstance3D] built for it.
+	func is_visual() -> bool:
+		return (definition
+				and definition is FuncGodotFGDSolidClass
+				and definition.build_visuals)
 	
 	## Checks the entity's FGD resource definition, returning whether the Solid Class CollisionShapeType is set to Convex.
 	func is_collision_convex() -> bool:

--- a/addons/func_godot/src/util/func_godot_util.gd
+++ b/addons/func_godot/src/util/func_godot_util.gd
@@ -166,6 +166,9 @@ static func build_texture_map(entity_data: Array[FuncGodotData.EntityData], map_
 			wad_resources.append(wad)
 	
 	for entity in entity_data:
+		if not entity.is_visual():
+			continue
+
 		for brush in entity.brushes:
 			for face in brush.faces:
 				var texture_name: String = face.texture


### PR DESCRIPTION
This was one I discovered by chance, and might not be broadly the behaviour the project wants, but I figured I'd try to fix it and highlight it anyways:

I created a special "trigger" texture, despite the fact I explicitly request the triggers to not build visuals (it's for the editor). However, because I put this texture in my "specials" folder, and didn't have a requisite "specials" folder in the materials folder, it threw an error every time I tried to build the map, complaining that it couldn't render out the material. No harm done, but I didn't need that material to generate anyway - the mesh that would use it never gets built.

I figure this is essentially a non-issue in 90% of projects, but this patch just makes it so that non-visual brushes aren't considered for material generation, as it seems like they'd never be used anyway. 

Only caveat I can foresee is if there's a reason I'm missing for non-visual brushes to generate materials.
