### PR TITLE
Include only plugin files for asset lib (.gitattributes)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Plugin export
+/** export-ignore
+/addons !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Added .gitattributes file with [export-ignore](https://git-scm.com/docs/gitattributes#_export_ignore) attributes. When [git archive](https://git-scm.com/docs/git-archive) command is executed, generated archive will not contain files marked by this attribute. [Github relies on this command](https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives#overview-of-source-code-archives) when you download source code via website. Considering that Asset Lib directly downloads zip from archive link, then this mean it's similarly affected by export-ignore.

.gitattributes in this PR is configured in a way, that every file is excluded, but when addons folder and it's contents are included back (more precisely, exclamation point changes export-ignore's state to unspecified).

I think this is convenient change for those who download this plugin from Asset Lib, because you don't need to manually uncheck readme and license files, they are already excluded and only plugin files are left. 

Also I just remembered, in my opinion, better to make a separate branch and add .gitattributes there, so you could always get full source code from main branch and Asset Lib could get only plugin files from new branch. 