### PR TITLE
Use is_inside_tree instead of get_tree to check if the map is in the tree

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -403,7 +403,7 @@ func generate_entity_node(entity_data: _EntityData, entity_index: int) -> Node:
 ## Main entity assembly process called by [FuncGodotMap]. Generates and sorts group nodes in the [SceneTree] first, 
 ## then generates and assembles [Node]s based upon the provided [FuncGodotData.EntityData] and adds them to the [SceneTree].
 func build(map_node: FuncGodotMap, entities: Array[_EntityData], groups: Array[_GroupData]) -> void:
-	var scene_root := map_node.get_tree().edited_scene_root if map_node.get_tree() else map_node
+	var scene_root := map_node.get_tree().edited_scene_root if map_node.is_inside_tree() else map_node
 	build_flags = map_node.build_flags
 	
 	if map_settings.use_groups_hierarchy:


### PR DESCRIPTION
These are functionally equivalent, however `get_tree()` prints an error message if the node is not in the scene tree, whereas `is_inside_tree()` does not. The code seems designed to handle the case where the node isn't in the tree, so it should be better to use the error-free version.

Docs: https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-get-tree

I got this error when building a map file at runtime:

```gdscript
var fgm := FuncGodotMap.new()
fgm.map_settings = map_settings
fgm.local_map_file = resource.resource_path
fgm.build() # <- error message printed here: entity_assembler.gd:406 @ build(): Parameter "data.tree" is null.
```