### PR TITLE
Unwrap UV2 on smooth shaded meshes after smoothing process

### DIFF
--- a/addons/func_godot/src/core/data.gd
+++ b/addons/func_godot/src/core/data.gd
@@ -154,6 +154,12 @@ class EntityData extends RefCounted:
 		return (definition
 				and definition is FuncGodotFGDSolidClass
 				and definition.build_visuals)
+
+	func is_gi_enabled() -> bool:
+		return (definition
+				and definition is FuncGodotFGDSolidClass
+				and definition.global_illumination_mode
+		)
 	
 	## Checks the entity's FGD resource definition, returning whether the Solid Class CollisionShapeType is set to Convex.
 	func is_collision_convex() -> bool:

--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -95,8 +95,16 @@ func generate_solid_entity_node(node: Node, node_name: String, data: _EntityData
 			node.add_child(occluder_instance)
 			data.occluder_instance = occluder_instance
 		
+		# NOTE: Currently occuring in EntityAssembler until the appropriate method in GeometryGenerator is resolved
+		# For now, smooth entire mesh, then unwrap for lightmap if needed
 		if not (build_flags & FuncGodotMap.BuildFlags.DISABLE_SMOOTHING) and data.is_smooth_shaded(map_settings.entity_smoothing_property):
 			mesh_instance.mesh = FuncGodotUtil.smooth_mesh_by_angle(data.mesh, data.get_smoothing_angle(map_settings.entity_smoothing_angle_property))
+
+			if data.is_gi_enabled() and (build_flags & FuncGodotMap.BuildFlags.UNWRAP_UV2):
+				mesh_instance.mesh.lightmap_unwrap(
+					Transform3D.IDENTITY,
+					map_settings.uv_unwrap_texel_size * map_settings.scale_factor
+				)
 
 	# Collision generation
 	if data.shapes.size() and node is CollisionObject3D:

--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -519,9 +519,11 @@ func generate_entity_surfaces(entity_index: int) -> void:
 
 func unwrap_uv2s(entity_index: int, texel_size: float) -> void:
 	var entity: _EntityData = entity_data[entity_index]
-	if entity.mesh:
-		if (entity.definition as FuncGodotFGDSolidClass).global_illumination_mode:
-			entity.mesh.lightmap_unwrap(Transform3D.IDENTITY, texel_size)
+	# NOTE: This skips smoothed meshes as they need to be unwrapped after smoothing.
+	# Ideally smoothing will be performed here in GeoGen before this process.
+	# For now, since it occurs in EntityAssembler, skip it.
+	if entity.mesh and entity.is_gi_enabled() and not entity.is_smooth_shaded(map_settings.entity_smoothing_property):
+		entity.mesh.lightmap_unwrap(Transform3D.IDENTITY, texel_size)
 
 # Main build process
 func build(build_flags: int, entities: Array[_EntityData]) -> Error:

--- a/addons/func_godot/src/util/func_godot_util.gd
+++ b/addons/func_godot/src/util/func_godot_util.gd
@@ -322,10 +322,10 @@ static func get_face_tangent(face: FuncGodotData.FaceData) -> PackedFloat32Array
 
 #region MESH
 
-static func smooth_mesh_by_angle(mesh: ArrayMesh, angle_deg: float = 89.0) -> Mesh:
+static func smooth_mesh_by_angle(mesh: ArrayMesh, angle_deg: float = 89.0) -> ArrayMesh:
 	if not mesh:
 		push_error("Need a source mesh to smooth")
-		return
+		return null
 	
 	var angle: float = deg_to_rad(clampf(angle_deg, 0.0, 360.0))
 	


### PR DESCRIPTION
This PR adds a few small changes to the UV2 unwrap process.

Currently, mesh unwrap occurs in geometry_generator. However, if a mesh is smooth shaded, this is seemingly discarded by the new ArrayMesh returned by `smooth_mesh_by_angle`. So, when a user desired UV2 unwrapping, only non-smoothed meshes would be unwrapped.

This fix should be reverted when smooth shading is moved back into Geometry Generator, as the unwrap would occur after that process already. See the notes in code for more explanation.

As such, if a mesh is detected as using non-disabled global illumination and UV2 unwrap is enabled, it is skipped in GeometryGenerator and instead unwrapped after smoothing in EntityAssembler.

To address typing, `smooth_mesh_by_angle` now returns an ArrayMesh (no code changes, as this is already what was returned)

Should resolve #162 

cc: @RhapsodyInGeek regarding lightmap_unwrap's transform argument - [according to the Godot source code](https://github.com/godotengine/godot/blob/3c7f9b937214068bc892be0d2bd9a8a7026edae1/scene/resources/mesh.cpp#L2083) the lightmap unwrap transform input only reads the scale so I believe this is still in line with what's expected rather than inputting a 3D transform representing the object's position but wanted your thoughts