### PR TITLE
Merge face vertices when doing rounding

### DIFF
--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -8,7 +8,7 @@ const _SIGNATURE: String = "[GEO]"
 const _VERTEX_EPSILON 	:= FuncGodotUtil._VERTEX_EPSILON
 const _VERTEX_EPSILON2 	:= _VERTEX_EPSILON * _VERTEX_EPSILON
 
-const _HYPERPLANE_SIZE	:= 65355.0
+const _HYPERPLANE_SIZE	:= 32768.0
 
 const _OriginType 	:= FuncGodotFGDSolidClass.OriginType
 
@@ -121,9 +121,17 @@ func generate_face_vertices(brush: _BrushData, face_index: int, vertex_merge_dis
 		if winding.is_empty():
 			break
 	
-	# Reduce seams between vertices
-	for i in winding.size():
-		winding.set(i, winding.get(i).snappedf(vertex_merge_distance))
+	# Perform rounding and merge adjacent vertices that are equivalent
+	if vertex_merge_distance > 0:
+		var merged_winding : PackedVector3Array = PackedVector3Array()
+		var prev_vtx : Vector3 = winding[0].snappedf(vertex_merge_distance)
+		merged_winding.append(prev_vtx)
+		for i in range(1, winding.size()):
+			var cur_vtx : Vector3 = winding[i].snappedf(vertex_merge_distance)
+			if prev_vtx != cur_vtx:
+				merged_winding.append(cur_vtx)
+			prev_vtx = cur_vtx
+		winding = merged_winding
 
 	return winding
 


### PR DESCRIPTION
This is an attempt to help with situations when floating point rounding issues cause too many vertices to be generated for a winding. Usually this just creates tiny triangles that are effectively invisible, but when used in combination with the 'vertex merge distance' option, it was causing faces to be visually flipped, in a way I don't quite understand (since the rounding doesn't change the vertex order).

This hopefully eliminates the problem at the source by merging adjacent vertices that would become equal once rounding is applied. It also does the rounding at the same time.

I also modified the hyperplane size to match TB - which adds 32k either side of the point to form the plane, not 64k. (see: https://github.com/TrenchBroom/TrenchBroom/blob/e6de999ff204e2f084cc38738af57e1cb57aca74/common/src/ui/MapDocument.cpp#L387) Each time the hyperplane size is reduced by 2 it reduces precision errors by an order of magnitude, so its good to keep it as low as possible. (I've been using 4096 on my local copy)

Here's an example brush from the discord convo:
```
// entity 0
{
"classname" "func_detail"
"_vertex_merge_distance" "0.008"
// brush 0
{
( -484 1812 408 ) ( -504 1880 424 ) ( -504 1880 488 ) special/skip [ 0.28216632399155017 -0.9593655015712707 0 17.097168 ] [ 0 0 -1 8 ] 90 1 1
( -416 1896 424 ) ( -416 1896 488 ) ( -504 1880 488 ) special/skip [ -0.9838699100999074 -0.17888543819998318 0 16.211823 ] [ 0 0 -1 8 ] 90 1 1
( -504 1880 488 ) ( -420 1812 428 ) ( -484 1812 420 ) __TB_empty [ 0.9928100471826482 -0.1197005021425888 0 -21.360046 ] [ -0.08278854640277541 -0.6866579436936078 -0.7222512893356313 6.96521 ] 90 1 1
( -484 1812 408 ) ( -416 1896 424 ) ( -504 1880 424 ) special/skip [ -0.9991764674208538 0 0.040575694108461076 10.129303 ] [ -0.008837728546011142 -0.9759915391167358 -0.21762906544552432 7.326782 ] 90 1 1
( -484 1812 420 ) ( -420 1812 428 ) ( -420 1812 408 ) special/skip [ 1 0 0 0 ] [ 0 0 -1 8 ] 90 1 1
( -420 1812 408 ) ( -416 1896 424 ) ( -484 1812 408 ) special/skip [ -1 0 0 0 ] [ 0 -0.9823385664224747 -0.1871121078899952 5.428589 ] 90 1 1
( -504 1880 488 ) ( -416 1896 488 ) ( -420 1812 428 ) __TB_empty [ 0.9915278238317844 0 -0.12989447473778837 -29.720398 ] [ -0.07550900044200032 -0.8136819378942904 -0.5763853700406024 21.06897 ] 90 1 1
( -420 1812 428 ) ( -416 1896 488 ) ( -416 1896 424 ) special/skip [ 0.04756514941544941 0.9988681377244376 0 -23.901611 ] [ 0 0 -1 8 ] 90 1 1
}
}
```

Before:
<img width="404" height="305" alt="image" src="https://github.com/user-attachments/assets/ebe05c3d-6879-4915-a11c-eafa20152136" />

```
vertices for the visible faces after rounding
[(344.0, 289.0, 197.0), (344.0, 289.0, 197.0), (280.0, 289.0, 189.0), (260.0, 357.0, 257.0)]
[(344.0, 289.0, 197.0), (260.0, 357.0, 257.0), (260.0, 357.0, 257.0), (348.0, 373.0, 257.0)]
```

After:
<img width="375" height="298" alt="image" src="https://github.com/user-attachments/assets/c62e64fb-beac-4125-8681-756c965a3829" />

```
vertices for the visible faces after merging
[(344.0, 289.0, 197.0), (280.0, 289.0, 189.0), (260.0, 357.0, 257.0)]
[(344.0, 289.0, 197.0), (260.0, 357.0, 257.0), (348.0, 373.0, 257.0)]
```