### PR TITLE
Skip attempting to auto-apply 'scale' property

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -341,6 +341,9 @@ func apply_entity_properties(node: Node, data: _EntityData) -> void:
 				
 		if def.auto_apply_to_matching_node_properties:
 			for property in properties:
+				if property == 'scale' and def is FuncGodotFGDPointClass and def.apply_scale_on_map_build:
+					# scale has already been applied
+					continue
 				if property in node:
 					if typeof(node.get(property)) == typeof(properties[property]):
 						node.set(property, properties[property])


### PR DESCRIPTION
When auto applying matching properties by name as well as auto applying the `scale` property in a point entity, an error is printed when scale is not a Vector3, as it conflicts with the `scale` property on the `Node3D` class. Unlike the other magic properties (e.g. mangle/angle/origin which map to `rotation_degrees` and `position`) the name in the Godot node is the same, so this can't be worked around in user code (except by not using `apply_scale_on_map_build` or `auto_apply_to_matching_node_properties`).

func_godot supports float, string, or Vector types in the `scale` property (so re-doing type conversion is non-trivial), and the scale has already been applied in the `generate_point_entity_node` function, so the easiest way is to simply skip the `scale` property when auto-applying properties of the same name.

The error that is printed:
```
ERROR: core/variant/variant_utility.cpp:1024
Entity <name> property 'scale' type mismatch with matching generated node property.
```