### PR TITLE
Update parsing default angle property from Trenchbroom

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -187,7 +187,12 @@ func generate_point_entity_node(node: Node, node_name: String, properties: Dicti
 			var angle = properties["angle"]
 			if not angle is float:
 				angle = float(angle)
-			angles.y += angle
+			if is_equal_approx(angle, -1):
+				angles.x = 90
+			elif is_equal_approx(angle, -2):
+				angles.x = -90
+			else:
+				angles.y += angle
 		angles.y += 180
 		node.rotation_degrees = angles
 	


### PR DESCRIPTION
When rotating entities in TrenchBroom, it automatically adds the `angle` property that specifies an angle of rotation around the UP axis. There are 2 special values for pointing straight up and straight down, -1 and -2 respectively. Currently these are just subtracted from the default 180 rotation in func_godot, but it would be nice to match the behavior in TrenchBroom.

This arose from a need to create a downward facing spotlight entity.