### PR TITLE
Correct UV scale construction

### DIFF
--- a/addons/func_godot/src/util/func_godot_util.gd
+++ b/addons/func_godot/src/util/func_godot_util.gd
@@ -232,9 +232,9 @@ static func build_texture_map(entity_data: Array[FuncGodotData.EntityData], map_
 ## Returns UV coordinate calculated from the Valve 220 UV format.
 static func get_valve_uv(vertex: Vector3, u_axis: Vector3, v_axis: Vector3, uv_basis := Transform2D.IDENTITY, texture_size := Vector2.ONE) -> Vector2:
 	var uv := Vector2(u_axis.dot(vertex), v_axis.dot(vertex))
-	uv += (uv_basis.origin * uv_basis.get_scale())
-	uv.x /= uv_basis.x.x
-	uv.y /= uv_basis.y.y
+	var scale := Vector2(uv_basis.x.x, uv_basis.y.y)
+	uv += (uv_basis.origin * scale)
+	uv /= scale;
 	uv.x /= texture_size.x
 	uv.y /= texture_size.y
 	return uv


### PR DESCRIPTION
In the calculation for `get_valve_uv()`, `Transform2D.get_scale()` returned a flipped value, i.e.:

```
# This is about what you'd expect from (+, +)
basis: [X: (0.03125, 0.0), Y: (0.0, 0.03125), O: (32.0, -64.0)] | scale (0.03125, 0.03125) 

# We actually need the X scale to be negative here, but get_scale() returned (+, -)
basis: [X: (-0.03125, 0.0), Y: (0.0, 0.03125), O: (32.0, -64.0)] | scale (0.03125, -0.03125)
```

which was incongruent with how we actually stored said values.

It remains to be determined if this should actually be flipped in the parser or in the UV calculation here, but I don't think anyone's manually calling `get_valve_uv()` with a custom Transform2D. In the future, that should probably be looked at a bit more closely if needed.