### PR TITLE
Made generated model size respect default inverse scale factor

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_model_point_class.gd
@@ -65,7 +65,10 @@ func _generate_model() -> void:
 	if target_map_editor == TargetMapEditor.TRENCHBROOM:
 		const model_key: String = "model"
 		if scale_expression.is_empty():
-			meta_properties[model_key] = '"%s"' % _get_local_path()
+			meta_properties[model_key] = '{"path": "%s", "scale": %s }' % [
+				_get_local_path(), 
+				ProjectSettings.get_setting("func_godot/default_inverse_scale_factor", 32.0) as float
+			]
 		else:
 			meta_properties[model_key] = '{"path": "%s", "scale": %s }' % [
 				_get_local_path(), 


### PR DESCRIPTION
The docstring for the model point's `scale_factor` field says

> Scale expression applied to model. Only used by TrenchBroom. If left empty, uses [member ProjectSettings.func_godot/default_inverse_scale_factor]. Read the TrenchBroom Manual for more information on the "scale expression" feature.

But when generating the glbs, if no scale expression is set, then it does not use the default inverse scale factor on the generated model.

This change fixes that. So now no scale expression will be the same as the project wide inverse scale factor.