### PR TITLE
Add a list of groups as an option for all entities

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -398,13 +398,15 @@ func generate_entity_node(entity_data: _EntityData, entity_index: int) -> Node:
 	elif entity_def is FuncGodotFGDPointClass:
 		node = generate_point_entity_node(node, node_name, properties, entity_def)
 	
-	if node and entity_def.script_class:
-		node.set_script(entity_def.script_class)
-	if node and entity_def.group_names:
-		for group_name in entity_def.group_names:
-			if group_name == "":
-				continue
-			node.add_to_group(group_name, true);
+	if node:
+		if entity_def.script_class:
+			node.set_script(entity_def.script_class)
+		
+		if entity_def.node_groups:
+			for node_group in entity_def.node_groups:
+				if node_group == "":
+					continue
+				node.add_to_group(node_group, true)
 	
 	return node
 

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -55,7 +55,7 @@ var prefix: String = ""
 @export var name_property := ""
 
 ## Optional Array of group names assigned when generating the node
-@export var group_names : Array[String] = ["func_godot_entity"]
+@export var node_groups : Array[String] = []
 
 ## Parses the definition and outputs it into the FGD format.
 func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM) -> String:


### PR DESCRIPTION
Add a list of groups as an option for all entities. Addresses #173 , @LogicAndTrick let me know if this was what you had in mind? Something I'm also finding myself needing for entities that are markers and I get them by group names(procgen).

This shouldn't be a breaking change if users are currently adding groups in `_func_godot_apply_properties`. This accounts for the case where there is an empty string. This also currently defines the array of groups with "func_godot_entity" as a default group, though this can be removed from the array of group names if the user doesn't want it