### PR TITLE
Add option in Map Settings for using a unique shader for generated materials

### DIFF
--- a/addons/func_godot/src/map/func_godot_map_settings.gd
+++ b/addons/func_godot/src/map/func_godot_map_settings.gd
@@ -114,10 +114,6 @@ var scale_factor: float = 0.03125
 ## [i]NOTE: Materials do not use the [member default_material] settings after saving.[/i]
 @export var save_generated_materials: bool = true
 
-## When saving a generated material, whether to make a unique shader or use a reference to the shader.
-## [i]NOTE: Only relevant if [member save_generated_materials] is true and [member default_material] is a Shader Material.[/i]
-@export var unique_shader: bool = false
-
 #endregion
 
 @export_category("UV Unwrap")

--- a/addons/func_godot/src/util/func_godot_util.gd
+++ b/addons/func_godot/src/util/func_godot_util.gd
@@ -202,9 +202,7 @@ static func build_texture_map(entity_data: Array[FuncGodotData.EntityData], map_
 				
 				# Material generation
 				elif map_settings.default_material:
-					var material = map_settings.default_material.duplicate(true)
-					if material is ShaderMaterial and !map_settings.unique_shader:
-						material.shader = map_settings.default_material.shader;
+					var material = map_settings.default_material.duplicate(false)
 					var texture: Texture2D = load_texture(texture_name, wad_resources, map_settings)
 					texture_sizes[texture_name] = texture.get_size()
 					


### PR DESCRIPTION
Addresses first half of #178 . Makes things a lot less tedious if you have a lot of textures all sharing a common shader.

For now I've defaulted it to false(meaning it will not generate a unique shader). I think this is a sensible default because this should prevent mistakes writing shaders(writing the shader to a generated material and not the global and saved shader file), and maybe avoid some shader compilation costs as it's all a common shader(though I'm not as sure on this 🤔)