### PR TITLE
Add optional partitioning of solid class meshes

### DIFF
--- a/addons/func_godot/src/core/data.gd
+++ b/addons/func_godot/src/core/data.gd
@@ -135,9 +135,9 @@ class EntityData extends RefCounted:
 	## This can only be a [FuncGodotFGDSolidClass], [FuncGodotFGDPointClass], or [FuncGodotFGDModelPointClass].
 	var definition: FuncGodotFGDEntityClass = null
 	## Mesh resource generated during the geometry generation stage and applied during the entity assembly stage.
-	var mesh: ArrayMesh = null
+	var meshes: Array[ArrayMesh] = []
 	## MeshInstance3D node generated during the entity assembly stage.
-	var mesh_instance: MeshInstance3D = null
+	var mesh_instances: Array[MeshInstance3D] = []
 	## Optional mesh metadata compiled during the geometry generation stage, used to determine face information from collision.
 	var mesh_metadata: Dictionary = {}
 	## A collection of collision shape resources generated during the geometry generation stage and applied during the entity assembly stage.
@@ -145,7 +145,7 @@ class EntityData extends RefCounted:
 	## A collection of [CollisionShape3D] nodes generated during the entity assembly stage. Each node corresponds to a shape in the [member shapes] array.
 	var collision_shapes: Array[CollisionShape3D] = []
 	## [OccluderInstance3D] node generated during the entity assembly stage using the [member mesh] resource.
-	var occluder_instance: OccluderInstance3D = null
+	var occluder_instances: Array[OccluderInstance3D] = []
 	## True global position of the entity's generated node that the mesh's vertices are offset by during the geometry generation stage.
 	var origin: Vector3 = Vector3.ZERO
 

--- a/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_solid_class.gd
@@ -34,7 +34,7 @@ enum CollisionShapeType {
 	CONCAVE ## Should have a concave collision shape
 }
 
-## Controls whether this Solid Class is the worldspawn, is combined with the worldspawn, or is spawned as its own free-standing entity.
+## Controls whether this Solid Class is the worldspawn or is spawned as its own free-standing entity.
 @export var spawn_type: SpawnType = SpawnType.ENTITY
 ## Controls how this Solid Class determines its center position. Only valid if [member spawn_type] is set to ENTITY.
 @export var origin_type: OriginType = OriginType.BRUSH
@@ -50,7 +50,9 @@ enum CollisionShapeType {
 @export var shadow_casting_setting : GeometryInstance3D.ShadowCastingSetting = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 ## Automatically build [OccluderInstance3D] for this entity.
 @export var build_occlusion : bool = false
-## This Solid Class' [MeshInstance3D] will only be visible for [Camera3D]s whose cull mask includes any of these render layers.
+## The grid size to partition the brushes into multiple meshes. Leave at zero to disable partitioning.
+@export var partition_grid_size := Vector3.ZERO
+## This Solid Class' [MeshInstance3D]s will only be visible for [Camera3D]s whose cull mask includes any of these render layers.
 @export_flags_3d_render var render_layers: int = 1
 
 @export_group("Collision Build")


### PR DESCRIPTION
This might be a bit of a naive implementation so feedback is welcome, but what this change does is it adds a `partition_grid_size` property to `FuncGodotFGDSolidClass`, and if such is greater than `Vector3.ZERO`, brushes will be split into multiple meshes and occluders, depending on the center position of it's faces.

This is mainly for use with worldspawn, so that one can map as usual without having to separate everything into func_geo's without the associated performance impact on huge scenes.