### PR TITLE
Add Texture2D type check in FuncGodotUtil.load_texture()

### DIFF
--- a/addons/func_godot/src/util/func_godot_util.gd
+++ b/addons/func_godot/src/util/func_godot_util.gd
@@ -89,7 +89,11 @@ static func load_texture(texture_name: String, wad_resources: Array[QuakeWadFile
 	for texture_file_extension in map_settings.texture_file_extensions:
 		var texture_path: String = map_settings.base_texture_dir.path_join(texture_name + "." + texture_file_extension)
 		if ResourceLoader.exists(texture_path):
-			return load(texture_path)
+			var texture_file = load(texture_path)
+			if texture_file is Texture2D:
+				return texture_file
+			else:
+				printerr("Error: Texture load failed! (%s) not a valid Texture2D resource", texture_path)
 	
 	var texture_name_lower: String = texture_name.to_lower()
 	for wad in wad_resources:


### PR DESCRIPTION
Build process would crash Godot when loading a non-Texture2D resource ( #186 ). Added type check to prevent loading invalid resource types and warn the user when using an invalid type.