### PR TITLE
Fix invalid assignment error when calling QuakeWadFile._init

### DIFF
--- a/addons/func_godot/src/import/quake_wad_file.gd
+++ b/addons/func_godot/src/import/quake_wad_file.gd
@@ -10,5 +10,5 @@ class_name QuakeWadFile extends Resource
 ## Collection of [ImageTexture] imported from the WAD file.
 @export var textures: Dictionary[String, ImageTexture]
 
-func _init(textures: Dictionary = Dictionary()):
+func _init(textures: Dictionary[String, ImageTexture] = {}):
 	self.textures = textures


### PR DESCRIPTION
In Godot 4.5.1 game will crash with "Invalid assignment of property or key" error:
```
E 0:00:00:950   QuakeWadFile._init: Invalid assignment of property or key 'textures' with value of type 'Dictionary' on a base object of type 'Resource (QuakeWadFile)'.
  <GDScript Source>quake_wad_file.gd:14 @ QuakeWadFile._init()
  <Stack Trace> quake_wad_file.gd:14 @ _init()
```
