### PR TITLE
Fix Runtime Map Parse Failure From Carriage Returns

### DIFF
--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -55,9 +55,7 @@ func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _Pa
 				if data.is_empty():
 					printerr("Error: Failed to open map file (" + line + ")")
 					return parse_data
-				map_data = data.split("\r\n")
-				if (len(map_data) == 1):
-					map_data = data.split("\n")
+				map_data = data.replace("\r", "").split("\n")
 				break
 	else:
 		while not file.eof_reached():


### PR DESCRIPTION
I had a bizarre issue recently where for some reason, maps I recently edited wouldn't load in exported builds anymore.

After investigating it, I believe the issue is that since the newest release of Trenchbroom, it now saves newly edited maps with `\r\n` line endings on Windows.

Godot Editor handles it and changes line endings to `\n`, but exported builds do not.

---

With this change, map parser will first try to read the map assuming it uses `\r\n`, but if it fails, it will try reading it assuming it uses `\n`.