### PR TITLE
Allows FuncGodotMap to load raw map data.

### DIFF
--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -69,6 +69,28 @@ func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _Pa
 		declare_step.emit("Parsing as Source VMF")
 		parse_data = _parse_vmf(map_data, map_settings, parse_data)
 	
+	# Parse the actual map.
+	return parse_map(map_data, map_settings, parse_data)
+
+
+## Parses the raw data as Quake MAP, as with `parse_map_data(`, but using raw map data instead of a file path.
+func parse_raw_map_data(raw_data: String, map_settings: FuncGodotMapSettings) -> _ParseData:
+	var map_data: PackedStringArray = raw_data.replace("\r", "").split("\n")
+	var parse_data = _ParseData.new()
+	parse_data = _parse_quake_map(map_data, map_settings, parse_data)
+	return parse_map(map_data, map_settings, parse_data)
+
+
+## Parses the raw data as Source VMF, as with `parse_map_data(`, but using raw map data instead of a file path.
+func parse_raw_vmf_data(raw_data: String, map_settings: FuncGodotMapSettings) -> _ParseData:
+	var map_data: PackedStringArray = raw_data.replace("\r", "").split("\n")
+	var parse_data = _ParseData.new()
+	parse_data = _parse_vmf(map_data, map_settings, parse_data)
+	return parse_map(map_data, map_settings, parse_data)
+
+
+## Actual map parser.
+func parse_map(map_data: PackedStringArray, map_settings: FuncGodotMapSettings, parse_map: _ParseData) -> _ParseData:
 	# Determine group hierarchy
 	declare_step.emit("Determining groups hierarchy")
 	var groups_data: Array[_GroupData] = parse_data.groups


### PR DESCRIPTION
This allows FuncGodotMap to load and parse raw map data directly. This is not exposed to the editor. It's only exposed in code.

This is useful for a number of reasons, but I am using it to allow compressing map files for network transfer and map storage size reduction.

An example of use (although likely you'd want something other than a `QuakeMapFile`, like a network source or compressed file source):

```gdscript
extends FuncGodotMap

# within a class that is based on FuncGodotMap
func force_rebuild():
	#local_map_file = map.resource_path
	raw_data = FileAccess.get_file_as_bytes(map.resource_path).get_string_from_utf8()
	force_build_raw = ForceBuildRaw.QUAKE_MAP
	build()
	completed_build()
```

If there is a preferred difference in how this interface should function, let me know. I tried to minimize the diff. On paper this should both VMF and MAP file types, but I didn't test VMF.