### PR TITLE
Allows Entities to more easily reference eachother through node paths

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -56,7 +56,12 @@ func generate_solid_entity_node(node: Node, node_name: String, data: _EntityData
 	else:
 		node = Node3D.new()
 	
-	node.name = node_name
+	if node_name.begins_with("%"):
+		node_name = node_name.trim_prefix("%")
+		node.name = node_name
+		node.unique_name_in_owner = true
+	else:
+		node.name = node_name
 	node_name = node_name.trim_suffix(definition.classname).trim_suffix("_")
 	var properties: Dictionary[String, Variant] = data.properties
 	
@@ -286,7 +291,10 @@ func generate_entity_node(entity_data: _EntityData, entity_index: int) -> Node:
 	elif map_settings.entity_name_property in properties:
 		name_prop = str(properties[map_settings.entity_name_property])
 	if not name_prop.is_empty():
-		node_name = "entity_" + name_prop
+		if name_prop.begins_with("%"):
+			node_name = name_prop
+		else:
+			node_name = "entity_" + name_prop
 	
 	if entity_def is FuncGodotFGDSolidClass:
 		node = generate_solid_entity_node(node, node_name, entity_data, entity_def)

--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -213,7 +213,7 @@ func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _Pa
 					TYPE_STRING_NAME:
 						properties[property] = StringName(prop_string)
 					TYPE_NODE_PATH:
-						properties[property] = prop_string
+						properties[property] = NodePath(prop_string)
 					TYPE_OBJECT:
 						properties[property] = prop_string
 		

--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -213,7 +213,10 @@ func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _Pa
 					TYPE_STRING_NAME:
 						properties[property] = StringName(prop_string)
 					TYPE_NODE_PATH:
-						properties[property] = NodePath(prop_string)
+						if prop_string.begins_with("$") or prop_string.begins_with("%"):
+							properties[property] = NodePath(prop_string)
+						else:
+							properties[property] = prop_string
 					TYPE_OBJECT:
 						properties[property] = prop_string
 		


### PR DESCRIPTION
If you add NodePath to your FGD, the system currently treats it as a string. This parses these into NodePaths to match the type in the FGD.

Additionally, it allows you to name an Entity with Godot's `%node_name` syntax. Doing so does not add `entity_` to a node, but instead uses the raw literal name as written, but trims the `%` and flips the `unique_name_in_owner` to true.

These two changes combined allow nodes to reference each other easily through familiar Godot syntax.

### Note:

I wanted to retain the `entity_` thing, but there is no way to tell at time of authoring if a reference is `entity_` or something else the scene not controlled by FuncGodot (like a UI element that might want to light up when you enter an Area or something). Dropping `entity_` for these explicate naming conditions seemed reasonable to me.

If this breaks something else that expects `entity_` name, let me know and we can try to figure out another solution.

# Examples

How this looks in Trenchbroom:

<img width="2383" height="707" alt="image" src="https://github.com/user-attachments/assets/581316f2-fad0-40ae-97d3-713d033c34fc" />

How it parses into Godot, notice the `@export var testTarget:NodePath` loads as reference to the other node:

<img width="2901" height="977" alt="image" src="https://github.com/user-attachments/assets/59e50132-b659-42eb-b9d4-43256b82f6e3" />

What the FGD looks like: 

<img width="762" height="491" alt="image" src="https://github.com/user-attachments/assets/ebafaab4-14ac-44a3-bc02-7710f019a087" />

I don't know if this will break existing projects. If there might be another way to handle this, I'm open to changes.