### PR TITLE
Add set_default_properties to TrenchBroom GameConfig

### DIFF
--- a/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
+++ b/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
@@ -52,6 +52,10 @@ enum GameConfigVersion {
 ## See [url="https://trenchbroom.github.io/manual/latest/#game_configuration_files_entities"]TrenchBroom Manual Entity Configuration Information[/url] for more information.
 @export var entity_scale: String = "32"
 
+## Controls whether default entity properties are instantiated automatically when TrenchBroom creates a new entity.
+## See [url="https://trenchbroom.github.io/manual/latest/#entity_properties_defaults"]TrenchBroom Manual Default Entity Properties[/url] for more information.
+@export var set_default_properties: bool = false
+
 ## Toggles whether [FuncGodotFGDModelPointClass] resources will generate models from their [PackedScene] files.
 @export var generate_model_point_class_models: bool = true
 
@@ -124,6 +128,7 @@ func _build_class_text() -> String:
 				palette_path,
 				fgd_filename_str,
 				entity_scale,
+				set_default_properties,
 				brush_tags_str,
 				brushface_tags_str,
 				uv_scale_str
@@ -304,7 +309,8 @@ func _get_game_config_v9v8_text() -> String:
 	"entities": {
 		"definitions": [ %s ],
 		"defaultcolor": "0.6 0.6 0.6 1.0",
-		"scale": %s
+		"scale": %s,
+		"setDefaultProperties": %s
 	},
 	"tags": {
 		"brush": [


### PR DESCRIPTION
Variables in the TB expression language don't seem to be evaluated if it needs to read from a default value. This option is useful in cases where the user would want all the defaults set when placing an entity.

For my specific use case, I am setting the scale for a display descriptor like so: `modelscale * 1024`.
Even if `modelscale` has a default value, the entity will not read from it. Causing the scale to be 0 until I manually set the `modelscale` property to something. This seems to be intended behavior: https://github.com/TrenchBroom/TrenchBroom/issues/4253#issuecomment-1856552776

Option has existed since config v6 so should be safe to add it to `_get_game_config_v9v8_text()`: https://trenchbroom.github.io/manual/latest/#versions