### PR TITLE
Add map import setting to exclude sky brushes

### DIFF
--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -18,6 +18,19 @@ const _ParseData	:= FuncGodotData.ParseData
 ## It is connected to [method FuncGodotUtil.print_profile_info] method if [member FuncGodotMap.build_flags] SHOW_PROFILE_INFO flag is set.
 signal declare_step(step: String)
 
+func _is_excluded_sky_brush(brush: _BrushData, map_settings: FuncGodotMapSettings) -> bool:
+	if not map_settings or not map_settings.exclude_sky_brushes:
+		return false
+	if not brush or brush.faces.is_empty():
+		return false
+	var texture_name: String = brush.faces[0].texture.to_lower()
+	if not texture_name.contains("sky"):
+		return false
+	for face in brush.faces:
+		if face.texture.to_lower() != texture_name:
+			return false
+	return true
+
 ## Parses the map file, generating entity and group data and sub-data, then returns the generated data as an array of arrays. 
 ## The first array is Array[FuncGodotData.EntityData], while the second array is Array[FuncGodotData.GroupData].
 func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _ParseData:
@@ -290,7 +303,8 @@ func _parse_quake_map(map_data: PackedStringArray, map_settings: FuncGodotMapSet
 		# Commit entity or brush
 		if line.begins_with("}"):
 			if brush:
-				ent.brushes.append(brush)
+				if not _is_excluded_sky_brush(brush, map_settings):
+					ent.brushes.append(brush)
 				brush = null
 			elif patch:
 				if scope:
@@ -496,7 +510,7 @@ func _parse_vmf(map_data: PackedStringArray, map_settings: FuncGodotMapSettings,
 				scope -= 1
 			if not scope:
 				if brush:
-					if brush.faces.size():
+					if brush.faces.size() and not _is_excluded_sky_brush(brush, map_settings):
 						ent.brushes.append(brush)
 					brush = null
 				elif ent:

--- a/addons/func_godot/src/map/func_godot_map_settings.gd
+++ b/addons/func_godot/src/map/func_godot_map_settings.gd
@@ -94,6 +94,10 @@ var scale_factor: float = 0.03125
 @export var origin_texture: String = "origin":
 	set(tex):
 		origin_texture = tex.to_lower()
+
+## If true, skip brushes where every face has the same texture and that texture name contains [code]"sky"[/code].
+## Matching is case-insensitive and based on the texture name only.
+@export var exclude_sky_brushes: bool = false
 @export_subgroup("")
 
 ## Optional [QuakeWadFile] resources to apply textures from. See the [Quake Wiki](https://quakewiki.org/wiki/Texture_Wad) for more information on Quake Texture WADs.


### PR DESCRIPTION
## Summary
Adds a new map setting to ignore sky brushes when they match a conservative rule:
- every face on the brush uses the same texture, and
- that texture name contains `sky` in its filename. (case-insensitive)

This is intentionally conservative  as to avoid filtering mixed-texture brushes, i.e. a brush that only has some faces with a sky texture.

Personally I would find this quite useful when I'm importing maps that were built for the base quake games, as I always end up going through and deleting all of the sky brushes manually in Trenchbroom before I import to Godot, since they usually serve no purpose.

## Changes
- Added `exclude_sky_brushes` to map settings:
  - `addons/func_godot/src/map/func_godot_map_settings.gd`
- Added brush filter helper in parser:
  - `addons/func_godot/src/core/parser.gd`
- Applied the filter at brush commit points for both parsers:
  - Quake MAP parser (`_parse_quake_map`)
  - VMF parser (`_parse_vmf`)


'Exclude Sky Brushes' == OFF
<img width="623" height="592" alt="Screenshot 2026-03-05 at 11 25 08 PM" src="https://github.com/user-attachments/assets/c0a705e7-c78b-49b2-8259-fe24435e24fc" />


'Exclude Sky Brushes' == ON
<img width="605" height="596" alt="Screenshot 2026-03-05 at 11 25 15 PM" src="https://github.com/user-attachments/assets/c58e3d9c-9f6b-4e02-a6ce-c45dd32f9185" />

