### PR TITLE
fix maps containing \r not reading correctly from exported builds

### DIFF
--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -271,7 +271,7 @@ func _parse_quake_map(map_data: PackedStringArray, map_settings: FuncGodotMapSet
 	var scope: int = 0 # Scope level, to keep track of where we are in PatchDef parsing
 	
 	for line in map_data:
-		line = line.replace("\t", "")
+		line = line.replace("\t", "").replace("\r", "")
 		
 		#region START DATA
 		# Start entity, brush, or patchdef


### PR DESCRIPTION
building maps at runtime from exported builds wasn't working for me because the map files had carriage returns in them, preventing the keyvalue parser from correctly stripping trailing double quotes. this pr fixes that by remiving carriage returns.