### PR TITLE
Reduce precision of coplanar detection in cull_interior_faces

### DIFF
--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -422,7 +422,7 @@ func generate_entity_surfaces(entity_index: int) -> void:
 					if face == face2:
 						continue
 					# Are the planes aligned?
-					if !face2.plane.has_point(face.plane.get_center()):
+					if !face2.plane.has_point(face.plane.get_center(), 0.0001):
 						continue
 					# Opposite planes
 					if !(face.plane.normal*-1.0).is_equal_approx(face2.plane.normal):


### PR DESCRIPTION
My map was getting lots of interior faces for unknown reasons. This change fixes that and makes cull_interior_faces more reliable.