### PR TITLE
Moved property type definition for "target_source"

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -215,9 +215,9 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 						prop_type = "decal"
 					elif value is AudioStream:
 						prop_type = "sound"
-				else:
-					prop_type = "target_source"
-					prop_val = "\"\""
+			TYPE_STRING_NAME:
+				prop_type = "target_source"
+				prop_val = "\"\""
 		
 		if prop_val:
 			res += "\t"


### PR DESCRIPTION
Related to this issue #215 
where Godot saves the `Object` Variant Type has an `null` in file when empty.

Changing the type fixes it.

It was moved from `TYPE_OBJECT` to `TYPE_STRING_NAME`, which was not been used and fits the use of `target_source`.
