### PR TITLE
Adds type check on `load(` in the map resource importer

### DIFF
--- a/addons/func_godot/src/import/quake_map_import_plugin.gd
+++ b/addons/func_godot/src/import/quake_map_import_plugin.gd
@@ -34,8 +34,11 @@ func _import(source_file, save_path, options, r_platform_variants, r_gen_files) 
 	var map_resource : QuakeMapFile = null
 
 	if ResourceLoader.exists(save_path_str):
-		map_resource = load(save_path_str) as QuakeMapFile
-		map_resource.revision += 1
+		map_resource = load(save_path_str)
+		if map_resource is QuakeMapFile:
+			map_resource.revision += 1
+		else:
+			map_resource = QuakeMapFile.new()		
 	else:
 		map_resource = QuakeMapFile.new()
 	map_resource.map_data = FileAccess.open(source_file, FileAccess.READ).get_as_text()


### PR DESCRIPTION
I ran into this issue on my project since I use a different map importer. This lets you go back to FuncGodot's QuakeMapFile.