### PR TITLE
Fix scene needing a manual save after map build/clear in Godot 4.5 and higher

### DIFF
--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -61,6 +61,7 @@ func clear_children() -> void:
 	for child in get_children():
 		remove_child(child)
 		child.queue_free()
+	EditorInterface.mark_scene_as_unsaved()
 
 ## Checks if a [QuakeMapFile] for the build process is provided and can be found.
 func verify() -> Error:


### PR DESCRIPTION
Fixes #242. Added `EditorInterface.mark_scene_as_unsaved()` to `clear_children`, which is called at the beginning of a map build.