### PR TITLE
Add checks for empty and duplicate FGD class names

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_file.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_file.gd
@@ -22,12 +22,12 @@ enum FuncGodotTargetMapEditors {
 func export_button() -> void:
 	do_export_file(target_map_editor)
 
-func do_export_file(target_editor: FuncGodotTargetMapEditors = FuncGodotTargetMapEditors.TRENCHBROOM, fgd_output_folder: String = "") -> void:
+func do_export_file(target_editor: FuncGodotTargetMapEditors = FuncGodotTargetMapEditors.TRENCHBROOM, fgd_output_folder: String = "") -> Error:
 	if fgd_output_folder.is_empty():
 		fgd_output_folder = FuncGodotLocalConfig.get_setting(FuncGodotLocalConfig.PROPERTY.FGD_OUTPUT_FOLDER) as String
 	if fgd_output_folder.is_empty():
 		printerr("Skipping export: No game config folder")
-		return
+		return ERR_DOES_NOT_EXIST
 
 	if fgd_name == "":
 		printerr("Skipping export: Empty FGD name")
@@ -35,18 +35,23 @@ func do_export_file(target_editor: FuncGodotTargetMapEditors = FuncGodotTargetMa
 	if not DirAccess.dir_exists_absolute(fgd_output_folder):
 		if DirAccess.make_dir_recursive_absolute(fgd_output_folder) != OK:
 			printerr("Skipping export: Failed to create directory")
-			return
+			return ERR_CANT_CREATE
+
+	var content := build_class_text(target_editor)
+	if content.is_empty():
+		return ERR_INVALID_DATA
 
 	var fgd_file = fgd_output_folder.path_join(fgd_name + ".fgd")
-	
 	var file_obj := FileAccess.open(fgd_file, FileAccess.WRITE)
 	if not file_obj:
 		printerr("Failed to open file for writing: ", fgd_file)
-		return
+		return ERR_FILE_CANT_OPEN
 	
 	print("Exporting FGD to ", fgd_file)
-	file_obj.store_string(build_class_text(target_editor))
+	file_obj.store_string(content)
 	file_obj.close()
+
+	return OK
 
 @export_group("Map Editor")
 
@@ -79,25 +84,54 @@ func do_export_file(target_editor: FuncGodotTargetMapEditors = FuncGodotTargetMa
 func build_class_text(target_editor: FuncGodotTargetMapEditors = FuncGodotTargetMapEditors.TRENCHBROOM) -> String:
 	var res : String = ""
 
-	for base_fgd in base_fgd_files:
+	for base_index in base_fgd_files.size():
+		var base_fgd = base_fgd_files[base_index]
 		if base_fgd is FuncGodotFGDFile:
 			res += base_fgd.build_class_text(target_editor)
 		else:
-			printerr("Base Fgd Files contains incorrect resource type! Should only be type FuncGodotFGDFile.")
-	
+			printerr("FGD base files array contains an element with invalid type (should be FuncGodotFGDFile) at position %s - skipping" % base_index)
+
 	var entities = get_fgd_classes()
-	for ent in entities:
-		if not ent is FuncGodotFGDEntityClass:
+
+	var classnames: Dictionary[String, int] = {}
+	var failure: bool = false
+
+	for ent_index in entities.size():
+		var ent = entities[ent_index]
+
+		if ent is not FuncGodotFGDEntityClass:
+			printerr("FGD entities array contains an element with invalid type (should be derived from FuncGodotFGDEntityClass) at position %s - skipping" % ent_index)
 			continue
 		if ent.func_godot_internal:
 			continue
 		if ent is FuncGodotFGDModelPointClass:
 			ent._model_generation_enabled = generate_model_point_class_models
+
+		if ent.classname.is_empty():
+			printerr("FGD class cannot be exported with empty classname (in position %s)" % ent_index)
+			failure = true
+			continue
+
+		if classnames.has(ent.classname):
+			printerr("Duplicate class name found: %s (in positions %s and %s)" % [
+				ent.classname,
+				classnames[ent.classname],
+				ent_index,
+			])
+			failure = true
+			continue
 		
+		classnames[ent.classname] = ent_index 
+
 		var ent_text = ent.build_def_text(target_editor)
 		res += ent_text
+
 		if ent != entities[-1]:
 			res += "\n"
+	
+	if failure:
+		return ""
+
 	return res
 
 ## This getter does a little bit of validation. Providing only an array of non-null uniquely-named entity definitions

--- a/addons/func_godot/src/netradiant_custom/netradiant_custom_gamepack_config.gd
+++ b/addons/func_godot/src/netradiant_custom/netradiant_custom_gamepack_config.gd
@@ -278,13 +278,13 @@ func export_file() -> void:
 					file.store_string('\t<var name="%s">%s</var>\n' % [key, default_build_menu_variables[key]])
 				
 				else:
-					push_error(
+					printerr(
 						"Variable key '%s' value '%s' is invalid type: %s; should be: String" % [
 						key, default_build_menu_variables[key], 
 						type_string(typeof(default_build_menu_variables[key]))
 						])
 			else:
-				push_error(
+				printerr(
 					"Variable '%s' is an invalid key type: %s; should be: String" % [
 						key, type_string(typeof(key))
 						])
@@ -302,14 +302,14 @@ func export_file() -> void:
 						if command is String:
 							file.store_string('\t\t<command>%s</command>\n' % command)
 						else:
-							push_error("Build option '%s' has invalid command: %s with type: %s; should be: String" % [
+							printerr("Build option '%s' has invalid command: %s with type: %s; should be: String" % [
 								key, command, type_string(typeof(command))
 								])	
 						
 					file.store_string('\t</build>\n')
 			
 			else:
-				push_error("Build option '%s' is an invalid type: %s; should be: String" % [
+				printerr("Build option '%s' is an invalid type: %s; should be: String" % [
 					key, type_string(typeof(key))
 					])
 		
@@ -318,5 +318,9 @@ func export_file() -> void:
 	# FGD
 	var export_fgd : FuncGodotFGDFile = fgd_file.duplicate()
 	export_fgd.generate_model_point_class_models = generate_model_point_class_models
-	export_fgd.do_export_file(FuncGodotFGDFile.FuncGodotTargetMapEditors.NET_RADIANT_CUSTOM, gamepacks_folder + "/" + gamepack_name + ".game/" + base_game_path)
-	print("NetRadiant Custom Gamepack export complete\n")
+	
+	var export_err := export_fgd.do_export_file(FuncGodotFGDFile.FuncGodotTargetMapEditors.NET_RADIANT_CUSTOM, gamepacks_folder + "/" + gamepack_name + ".game/" + base_game_path)
+	if export_err != OK:
+		printerr("Could not export FGD.")
+	else:
+		print("NetRadiant Custom Gamepack export complete\n")

--- a/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
+++ b/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
@@ -238,8 +238,13 @@ func export_file() -> void:
 	# FGD
 	var export_fgd : FuncGodotFGDFile = fgd_file.duplicate()
 	export_fgd.generate_model_point_class_models = generate_model_point_class_models
-	export_fgd.do_export_file(FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM, config_folder)
-	print("TrenchBroom Game Config export complete\n")
+
+	var export_err := export_fgd.do_export_file(FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM, config_folder)
+
+	if export_err != OK:
+		printerr("Could not export FGD.")
+	else:
+		print("TrenchBroom Game Config export complete\n")
 
 #region GameConfigDeclarations
 func _get_game_config_v4_text() -> String:


### PR DESCRIPTION
Resolves #247

This PR adjusts a few things related to entity FGD exporting when either an empty or duplicate classname has been found.

`FuncGodotFGDFile::do_export_file` now returns an `Error` type to indicate export failures, and will skip opening and writing to a file should an error be encountered. Both `TrenchBroomGameConfig` and `NetRadiantCustomGamePackConfig` now check for this error and report the failure.

Associated error handling messages in `FuncGodotFGDFile` have been adjusted to contain more specific information regarding where errors occurred to allow users to more easily pinpoint and resolve.

Unrelated to the FGD export related changes, some instances of `push_error` were adjusted to `printerr`, as the former will include an unnecessary link to Godot's inbuilt variant source code.

On the whole, this should likely be adjusted throughout the entire plugin, though it is not nearly as pressing.
