### PR TITLE
Specify Resource types on import

### DIFF
--- a/addons/func_godot/src/import/quake_map_import_plugin.gd
+++ b/addons/func_godot/src/import/quake_map_import_plugin.gd
@@ -8,7 +8,7 @@ func _get_visible_name() -> String:
 	return 'Quake Map'
 
 func _get_resource_type() -> String:
-	return 'Resource'
+	return 'QuakeMapFile'
 
 func _get_recognized_extensions() -> PackedStringArray:
 	return PackedStringArray(['map','vmf'])

--- a/addons/func_godot/src/import/quake_palette_import_plugin.gd
+++ b/addons/func_godot/src/import/quake_palette_import_plugin.gd
@@ -8,7 +8,7 @@ func _get_visible_name() -> String:
 	return 'Quake Palette'
 
 func _get_resource_type() -> String:
-	return 'Resource'
+	return 'QuakePaletteFile'
 
 func _get_recognized_extensions() -> PackedStringArray:
 	return PackedStringArray(['lmp'])

--- a/addons/func_godot/src/import/quake_wad_import_plugin.gd
+++ b/addons/func_godot/src/import/quake_wad_import_plugin.gd
@@ -29,7 +29,7 @@ func _get_visible_name() -> String:
 	return 'Quake WAD'
 
 func _get_resource_type() -> String:
-	return 'Resource'
+	return 'QuakeWadFile'
 
 func _get_recognized_extensions() -> PackedStringArray:
 	return PackedStringArray(['wad'])


### PR DESCRIPTION
Changes generic `Resource` string to specific string of imported resource.

This allows for `EditorFileSystem.get_file_type()` string comparison to detect a specific resource type.