### PR TITLE
FGD: if Object is unknown Resource, default to target_source

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -215,6 +215,9 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 						prop_type = "decal"
 					elif value is AudioStream:
 						prop_type = "sound"
+					else:
+						prop_type = "target_source"
+						prop_val = "\"\""
 				else:
 					prop_type = "target_source"
 					prop_val = "\"\""


### PR DESCRIPTION
When I set my type to Object, it's not saved and reverted when i re-open godot. I  set it to Resource instead, but this produces a syntax error due to the res:// path. This change makes it a target_source if the Resource type is unknown, because it would have produced a syntax error anyways.