### PR TITLE
Default `TrenchBroomGameConfig.palette_path` to empty string.

### DIFF
--- a/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
+++ b/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
@@ -40,7 +40,7 @@ enum GameConfigVersion {
 @export var texture_exclusion_patterns: Array[String] = ["*_albedo", "*_ao", "*_emission", "*_height", "*_metallic", "*_normal", "*_orm", "*_roughness", "*_sss"]
 
 ## Palette path relative to your Game Path. Only needed for Quake WAD2 files. Half-Life WAD3 files contain the palettes within the texture information.
-@export var palette_path: String = "textures/palette.lmp"
+@export var palette_path: String = ""
 
 @export_group("Entities")
 


### PR DESCRIPTION
If this file does not exist, it causes the latest TrenchBroom to fail to load materials.

TrenchBroom does not consider this a bug and will not fix it: https://github.com/TrenchBroom/TrenchBroom/issues/5335

Making this string default to empty will make prevent loading issues.