### PR TITLE
Better method of specifying a target source property type for FGD entities

### DIFF
--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -297,9 +297,12 @@ func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _Pa
 						properties[property] = prop_default[prop_default.keys().front()]
 					else:
 						properties[property] = 0
-				# Materials, Shaders, and Sounds
+				# Materials, Shaders, Sounds, and special property types
 				elif prop_default is Resource:
-					properties[property] = prop_default.resource_path
+					if prop_default is FuncGodotTargetSourceProperty:
+						properties[property] = ""
+					else:
+						properties[property] = prop_default.resource_path
 				# Target Destination and Target Source
 				elif prop_default is NodePath or prop_default is Object or prop_default == null:
 					properties[property] = ""

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -215,6 +215,9 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 						prop_type = "decal"
 					elif value is AudioStream:
 						prop_type = "sound"
+					elif value is FuncGodotTargetSourceProperty:
+						prop_type = "target_source"
+						prop_val = "\"\""
 				else:
 					prop_type = "target_source"
 					prop_val = "\"\""

--- a/addons/func_godot/src/fgd/func_godot_target_source_property.gd
+++ b/addons/func_godot/src/fgd/func_godot_target_source_property.gd
@@ -1,0 +1,3 @@
+class_name FuncGodotTargetSourceProperty
+extends Resource
+## Special resource used to indicate that an FGD entity property is of type "target_source"

--- a/addons/func_godot/src/fgd/func_godot_target_source_property.gd.uid
+++ b/addons/func_godot/src/fgd/func_godot_target_source_property.gd.uid
@@ -1,0 +1,1 @@
+uid://dkhtfq0fu81pm


### PR DESCRIPTION
This is an alternate take on fixing #215 as opposed to using `StringName` like #240 and I believe sets a better standard for how to handle "extended" property types going forward.

The idea is that to make a target_source property you make a new inline resource of type `FuncGodotTargetSourceProperty` instead of an `Object` (since that won't save properly and gets reset to null on reload of the entity definition resource).

<img width="506" height="103" alt="image" src="https://github.com/user-attachments/assets/02c2848a-1ee0-4657-b624-32c7585930fe" />

A benefit of this approach for future property type support is that additional options could be made available in the resource, such as a proper default value instead of it always being empty.


An alternate approach would be to have a more generic extended property data resource type for specifying custom FGD types like so:

```gdscript
class_name FuncGodotPropertyData
extends Resource

@export var prop_type: String
@export var prop_val: String
```

but that requires a bit more work.