### PR TITLE
Make Trenchbroom Config `set_default_properties` default to 'true'

### DIFF
--- a/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
+++ b/addons/func_godot/src/trenchbroom/trenchbroom_game_config.gd
@@ -54,7 +54,7 @@ enum GameConfigVersion {
 
 ## Controls whether default entity properties are instantiated automatically when TrenchBroom creates a new entity.
 ## See [url="https://trenchbroom.github.io/manual/latest/#entity_properties_defaults"]TrenchBroom Manual Default Entity Properties[/url] for more information.
-@export var set_default_properties: bool = false
+@export var set_default_properties: bool = true
 
 ## Toggles whether [FuncGodotFGDModelPointClass] resources will generate models from their [PackedScene] files.
 @export var generate_model_point_class_models: bool = true


### PR DESCRIPTION
## What is the current behaviour?

In Trenchbroom 2025.2 and later, when trying to rotate a point entity that has `mangle` or `angle` set, currently nothing happens until you manually change the default value of `mangle` to any value. You have to set it to any value (including the default value) before it can be rotated and that information can be saved to the map.

https://github.com/user-attachments/assets/a95fff94-f587-4c15-b43b-a7c0be7e0f92

## Is there a workaround for this behaviour?

Yes, you *can* tell Trenchbroom to set this value for you for **all entities** from `res://addons/func_godot/game_config/trenchbroom/func_godot_tb_game_config.tres` with the Set Default Properties property. This behaviour is documented in the Trenchbroom manual as `"setDefaultProperties": true` under `entities {}`: https://trenchbroom.github.io/manual/latest/#game_configuration_files_entities

Here is how to enable this setting in current func_godot.

<img width="452" height="812" alt="image" src="https://github.com/user-attachments/assets/7b1e5022-3966-4c3b-863f-8d3c243602c7" />

However, my argument is that the default behaviour should be *true*, for new users who want to see these entities rotate without editing the properties in the window. Users who want to have better organized properties in more complex projects should be the ones turning this setting off. I think this is more friendly default behaviour until Trenchbroom / Nextbroom changes how these properties are set/not set when these values are unset.

## What regressions does this PR cause?

This would cause new entities created in Trenchbroom maps to have all their properties set by default. This would cause map filesizes to grow and entities with a lot of properties to become harder to organize, as now there is no distinction between default values and custom values. But, this setting *can* be turned off for users who want the benefit of better organization. To me it's about what makes for a better for a new-user experience rather than what is the most useful.

<img width="464" height="393" alt="image" src="https://github.com/user-attachments/assets/b008bb92-253e-49ff-acee-b949ca4cd50e" />

(the current behaviour, where all default properties are nicely organized below the unique ones)

More *could* be done to ensure this legacy feature is respected in old projects, but I feel that as a simple on/off this is simple enough for old projects looking to keep the old behaviour. I know this issue may seem a bit silly but I did want to get input on this since I believe this used to be the default behaviour for a while. Feel free to discuss.