### PR TITLE
Add configuration to inject func_godot_properties into entity metadata 

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -278,6 +278,9 @@ func apply_entity_properties(node: Node, data: _EntityData) -> void:
 	if "func_godot_properties" in node:
 		node.func_godot_properties = properties
 	
+	if data.definition.add_properties_to_metadata:
+		node.set_meta("func_godot_properties", properties)
+
 	if node.has_method("_func_godot_apply_properties"):
 		node.call("_func_godot_apply_properties", properties)
 	

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -61,6 +61,9 @@ var prefix: String = ""
 ## This can be used to programmatically generate class properties when you need it
 @export var entity_extension_script: Script
 
+## Attaches entity properties from the entity onto the output node's metadata as `"func_godot_properties"`
+@export var add_properties_to_metadata : bool = false
+
 ## Parses the definition and outputs it into the FGD format.
 func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM) -> String:
 	# Class prefix


### PR DESCRIPTION
Support workflows that avoid custom scripts per entity type by injecting entity properties into object meta fields as a ~~fallback~~ configurable behavior.

My usecase is that architectually most of my entities are data containers, with behavior hoisted elsewhere.  It's largely unnecessary for me to make godot scripts for each one, so instead I opt to keep things as plain node types.  Still, I need to get the entity properties somehow at runtime, and it's more flexible to just access it through generic storage available on all godot object types.