### PR TITLE
Use a signal to trigger _func_godot_build_complete instead of using a deferred call

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -19,6 +19,9 @@ var build_flags: int = 0
 ## It is connected to [method FuncGodotUtil.print_profile_info] method if [member FuncGodotMap.build_flags] SHOW_PROFILE_INFO flag is set.
 signal declare_step(step: String)
 
+## Emitted when the map build is complete. [code]_func_godot_build_complete()[/code] is automatically connected to this for generated entities.
+signal build_complete
+
 func _init(settings: FuncGodotMapSettings) -> void:
 	map_settings = settings
 
@@ -250,7 +253,7 @@ func generate_point_entity_node(node: Node, node_name: String, properties: Dicti
 
 ## Converts the [String] values of the entity data's [code]properties[/code] [Dictionary] to various [Variant] formats 
 ## based upon the [FuncGodotFGDEntity]'s class properties, then attempts to send those properties to a [code]func_godot_properties[/code] [Dictionary] 
-## and an [code]_func_godot_apply_properties(properties: Dictionary)[/code] method on the node. A deferred call to [code]_func_godot_build_complete()[/code] is also made.
+## and an [code]_func_godot_apply_properties(properties: Dictionary)[/code] method on the node. A call to [code]_func_godot_build_complete()[/code] will be made once the rest of the map build completes.
 func apply_entity_properties(node: Node, data: _EntityData) -> void:
 	var properties: Dictionary[String, Variant] = data.properties
 	
@@ -282,7 +285,7 @@ func apply_entity_properties(node: Node, data: _EntityData) -> void:
 		node.call("_func_godot_apply_properties", properties)
 	
 	if node.has_method("_func_godot_build_complete"):
-		node.call_deferred("_func_godot_build_complete")
+		build_complete.connect(node.get("_func_godot_build_complete"), CONNECT_ONE_SHOT)
 
 ## Generate a [Node] from [FuncGodotData.EntityData]. The returned node value can be [code]null[/code], 
 ## in the case of [FuncGodotFGDSolidClass] entities with no [FuncGodotData.BrushData] entries.

--- a/addons/func_godot/src/map/func_godot_map.gd
+++ b/addons/func_godot/src/map/func_godot_map.gd
@@ -142,6 +142,7 @@ func build() -> void:
 		print("\nENTITY ASSEMBLER")
 		assembler.declare_step.connect(FuncGodotUtil.print_profile_info.bind(assembler._SIGNATURE))
 	assembler.build(self, entities, groups)
+	assembler.build_complete.emit()
 	
 	time_elapsed = Time.get_ticks_msec() - time_elapsed
 


### PR DESCRIPTION
This fixes some hidden issues with using func_godot as part of importing a scene (like with https://github.com/RisingThumb/func_godot_scene_import). If you try to run godot in import mode on the command-line (via `--import --headless`) the engine can finish importing a scene and quit before any deferred calls have a chance to run, thus resulting in `_func_godot_build_complete` never getting called on any entities.

Relying on deferred calls during a map build seems a bit iffy to me anyway, and means that `FuncGodotMap.build()` returns before everything has actually completed, which can lead to some weird bugs in user code.

There are a few ways I could have gone about this, but a signal that gets hooked up automatically seemed like a reasonable solution to me.