### PR TITLE
Allow _func_godot_build_complete to optionally take the entity_properties dictionary as an argument

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -283,9 +283,14 @@ func apply_entity_properties(node: Node, data: _EntityData) -> void:
 	
 	if node.has_method("_func_godot_build_complete"):
 		var complete_method : Callable = node.get("_func_godot_build_complete")
-		if complete_method.get_argument_count() > 0:
-			# Allow _func_godot_build_complete to optionally have properties passed to it
-			complete_method = complete_method.bind(properties)
+		match complete_method.get_argument_count():
+			0:
+				pass
+			1:
+				# Allow _func_godot_build_complete to optionally have properties passed to it
+				complete_method = complete_method.bind(properties)
+			_:
+				push_error("Entity %s script has a _func_godot_build_complete function with an incorrect number of arguments (expected 0 or 1) - the call may fail" % node.name)
 		complete_method.call_deferred()
 
 ## Generate a [Node] from [FuncGodotData.EntityData]. The returned node value can be [code]null[/code], 

--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -282,7 +282,11 @@ func apply_entity_properties(node: Node, data: _EntityData) -> void:
 		node.call("_func_godot_apply_properties", properties)
 	
 	if node.has_method("_func_godot_build_complete"):
-		node.call_deferred("_func_godot_build_complete")
+		var complete_method : Callable = node.get("_func_godot_build_complete")
+		if complete_method.get_argument_count() > 0:
+			# Allow _func_godot_build_complete to optionally have properties passed to it
+			complete_method = complete_method.bind(properties)
+		complete_method.call_deferred()
 
 ## Generate a [Node] from [FuncGodotData.EntityData]. The returned node value can be [code]null[/code], 
 ## in the case of [FuncGodotFGDSolidClass] entities with no [FuncGodotData.BrushData] entries.


### PR DESCRIPTION
This lets `_func_godot_build_complete` be defined on entities in either of these ways:

```gdscript
func _func_godot_build_complete() -> void:
  # do some stuff
  pass

func _func_godot_build_complete(entity_properties: Dictionary) -> void:
  # do some stuff, but with the entity's property dictionary
  pass
```

I feel that the latter is more generally useful, but for backwards-compatibility this should work with the former as well. My reasoning for this change is that I've found that I often need to lookup information about other nodes after the map build is complete (since they might not have been created by the time `_func_godo_apply_properties` is called), but the information I need to know what to do is contained within the entity properties dictionary which isn't passed to `_func_godot_build_complete`.

One workaround is to define a `func_godot_properties` property for the node, but that's a bit of a heavy-handed change as most of the time I don't want the full property dictionary stored as part of the node - I just need a couple of properties and I don't need them to persist.