### PR TITLE
Add a 'FuncGodotChoicesProperty' resource as an alternate (and simpler) way to define choices properties

### DIFF
--- a/addons/func_godot/src/core/parser.gd
+++ b/addons/func_godot/src/core/parser.gd
@@ -189,8 +189,12 @@ func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _Pa
 			var prop_string = entity.properties[property]
 			if property in def.class_properties:
 				var prop_default: Variant = def.class_properties[property]
+
+				var expected_type := typeof(prop_default)
+				if prop_default is FuncGodotChoicesProperty:
+					expected_type = typeof((prop_default as FuncGodotChoicesProperty).default_value)
 				
-				match typeof(prop_default):
+				match expected_type:
 					TYPE_INT:
 						properties[property] = prop_string.to_int()
 					TYPE_FLOAT:
@@ -297,9 +301,12 @@ func parse_map_data(map_file: String, map_settings: FuncGodotMapSettings) -> _Pa
 						properties[property] = prop_default[prop_default.keys().front()]
 					else:
 						properties[property] = 0
-				# Materials, Shaders, and Sounds
+				# Materials, Shaders, Sounds, and special property types
 				elif prop_default is Resource:
-					properties[property] = prop_default.resource_path
+					if prop_default is FuncGodotChoicesProperty:
+						properties[property] = (prop_default as FuncGodotChoicesProperty).default_value
+					else:	
+						properties[property] = prop_default.resource_path
 				# Target Destination and Target Source
 				elif prop_default is NodePath or prop_default is Object or prop_default == null:
 					properties[property] = ""

--- a/addons/func_godot/src/fgd/func_godot_choices_property.gd
+++ b/addons/func_godot/src/fgd/func_godot_choices_property.gd
@@ -1,0 +1,9 @@
+class_name FuncGodotChoicesProperty
+extends Resource
+## Special resource used to indicate that an FGD entity property is of type "choices".
+
+## The default value for this property.
+@export var default_value: Variant
+
+## The available choices for this property.
+@export var choices: Dictionary[Variant, String]

--- a/addons/func_godot/src/fgd/func_godot_choices_property.gd.uid
+++ b/addons/func_godot/src/fgd/func_godot_choices_property.gd.uid
@@ -1,0 +1,1 @@
+uid://2kdqpare8d4w

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -215,6 +215,17 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 						prop_type = "decal"
 					elif value is AudioStream:
 						prop_type = "sound"
+					elif value is FuncGodotChoicesProperty:
+						prop_type = "choices"
+						prop_val = FuncGodotUtil.newline() + "\t[" + FuncGodotUtil.newline()
+						var choices_prop := value as FuncGodotChoicesProperty
+						for choice_value in choices_prop.choices:
+							var choice_name := choices_prop.choices[choice_value]
+							if choice_value is String and not (choice_value as String).begins_with("\""):
+								choice_value = "\"" + choice_value + "\""
+							prop_val += "\t\t" + str(choice_value) + " : \"" + choice_name + "\"" + FuncGodotUtil.newline()
+						prop_val += "\t]"
+						prop_description += " : " + str(choices_prop.default_value)
 				else:
 					prop_type = "target_source"
 					prop_val = "\"\""
@@ -233,7 +244,7 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 			
 			if value is bool:
 				res += " : 1 = " if value else " : 0 = "
-			elif value is Dictionary or value is Array:
+			elif value is Dictionary or value is Array or value is FuncGodotChoicesProperty:
 				res += " = "
 			else:
 				res += " : "


### PR DESCRIPTION
This is based on the same technique I used in #261 for defining special property types.

This adds a new `FuncGodotChoicesProperty` resource that can be used instead of the somewhat clunky method of defining choices properties via a dictionary. Now you define the property default as the new `FuncGodotChoicesProperty` type (select `Object` as the type, then make a new `FuncGodotChoicesProperty` or select an existing resource) which is _much_ simpler to setup and doesn't require using the property descriptions to set a default value.

<img width="513" height="331" alt="image" src="https://github.com/user-attachments/assets/d69ea728-e2fb-4e1b-bc53-a7af05b9e5d8" />

<img width="356" height="442" alt="image" src="https://github.com/user-attachments/assets/04c3b2f6-1a0e-4d50-b0c3-1c8471cec5d2" />

An extra benefit of this method is that you can create shared choices resources if you have multiple properties that have the same choices (like for shared enums).