### PR TITLE
Fixes ABSOLUTE+RELATIVE origin_types and makes it read default values

### DIFF
--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -212,13 +212,18 @@ func determine_entity_origins(entity_index: int) -> void:
 		match origin_type:
 			_OriginType.ABSOLUTE, _OriginType.RELATIVE:
 				if "origin" in entity.properties:
-					var origin_comps: PackedFloat64Array = entity.properties["origin"].split_floats(" ")
-					if origin_comps.size() > 2:
-						if entity.origin_type == _OriginType.ABSOLUTE:
-							entity.origin = Vector3(origin_comps[0], origin_comps[1], origin_comps[2]) * map_settings.scale_factor
+					var new_origin = entity.properties["origin"]
+					if new_origin is Vector3 or new_origin is Vector3i:
+						new_origin = Vector3(new_origin)
+					else:
+						var origin_comps: PackedFloat64Array = new_origin.split_floats(" ")
+						new_origin = Vector3(origin_comps[0], origin_comps[1], origin_comps[2])
+					if new_origin != Vector3.INF:
+						if origin_type == _OriginType.ABSOLUTE:
+							entity.origin = new_origin * map_settings.scale_factor
 						else: # _OriginType.RELATIVE
-							entity.origin += Vector3(origin_comps[0], origin_comps[1], origin_comps[2]) * map_settings.scale_factor
-				
+							entity.origin += new_origin * map_settings.scale_factor
+
 			_OriginType.BRUSH:
 				if origin_mins != Vector3.INF:
 					entity.origin = origin_maxs - ((origin_maxs - origin_mins) * 0.5)


### PR DESCRIPTION
There was an actual typo here that made this feature non functional. `entity.origin_type` should have been either `entity.definition.origin_type` or just `origin_type`. While I was in here, I added some functionality and would like to know if that's okay or you want me to clean it out and JUST fix the one broken line:

- When an EntityDefinition has this origin_type but this entity does not contain this property, should FuncGodot default to ignore (previous behavior), default to Vector3.ZERO, or use the FGD `class_properties` value ? I chose to default to FGD `class_properties` value. I can remove that to match old behavior if preferred. For my project, I preferred FGD value. Since every SolidClass has it's own `origin_type` that must be set, I didn't think looking into the base classes was necessary here. Since this wasn't working before, I don't think the risk of this breaking anyone is very high.

- Should the vector be swizzled to match Godot's XYZ instead of Quake map concordant space? I don't think FuncGodot does that when writing other Vector3 properties , so I didn't do that here. `meta_properties["size"]` I believe is in Quake vector format & Quake scale but other `class_properties` I don't think get swizzled. This gets Godot scaled, but not swizzled, so I wasn't sure what the correct thing here was. I matched what was here previously, but it didn't quite sit right with me. 
