### PR TITLE
Add a way for the wound vertices to be overriden in an entity definition

### DIFF
--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -106,7 +106,7 @@ func generate_base_winding(plane: Plane) -> PackedVector3Array:
 	winding.append(centroid + (right *  h) + (forward * -h))
 	return winding
 
-func generate_face_vertices(brush: _BrushData, face_index: int, vertex_merge_distance: float = 0.0) -> PackedVector3Array:
+func generate_face_vertices(brush: _BrushData, face_index: int, entity: _EntityData, vertex_merge_distance: float = 0.0) -> PackedVector3Array:
 	var plane: Plane = brush.faces[face_index].plane
 	
 	# Generate initial square polygon to clip other planes against
@@ -133,6 +133,12 @@ func generate_face_vertices(brush: _BrushData, face_index: int, vertex_merge_dis
 				merged_winding.append(cur_vtx)
 			prev_vtx = cur_vtx
 		winding = merged_winding
+	
+	if entity.definition.brush_winding_overrider:
+		var ex: RefCounted = entity.definition.brush_winding_overrider.new()
+		if ex.has_method("_func_godot_modify_vertex_wind"):
+			ex.call("_func_godot_modify_vertex_wind", winding, entity)
+
 
 	return winding
 
@@ -143,7 +149,7 @@ func generate_brush_vertices(entity_index: int, brush_index: int) -> void:
 	
 	for face_index in brush.faces.size():
 		var face: _FaceData = brush.faces[face_index]
-		face.vertices = generate_face_vertices(brush, face_index, vertex_merge_distance)
+		face.vertices = generate_face_vertices(brush, face_index, entity, vertex_merge_distance)
 		
 		face.normals.resize(face.vertices.size())
 		face.normals.fill(face.plane.normal)

--- a/addons/func_godot/src/core/geometry_generator.gd
+++ b/addons/func_godot/src/core/geometry_generator.gd
@@ -110,7 +110,7 @@ func generate_face_vertices(brush: _BrushData, face_index: int, entity: _EntityD
 	var plane: Plane = brush.faces[face_index].plane
 	
 	# Generate initial square polygon to clip other planes against
-	var winding: PackedVector3Array = generate_base_winding(plane)
+	var vertices: PackedVector3Array = generate_base_winding(plane)
 
 	for other_face_index in brush.faces.size():
 		if other_face_index == face_index:
@@ -118,29 +118,29 @@ func generate_face_vertices(brush: _BrushData, face_index: int, entity: _EntityD
 		
 		# NOTE: This may need to be recentered to the origin, then moved back to the correct face position
 		# This problem may arise from floating point inaccuracy, given a large enough initial brush
-		winding = Geometry3D.clip_polygon(winding, brush.faces[other_face_index].plane)
-		if winding.is_empty():
+		vertices = Geometry3D.clip_polygon(vertices, brush.faces[other_face_index].plane)
+		if vertices.is_empty():
 			break
 	
 	# Perform rounding and merge adjacent vertices that are equivalent
 	if vertex_merge_distance > 0:
-		var merged_winding : PackedVector3Array = PackedVector3Array()
-		var prev_vtx : Vector3 = winding[0].snappedf(vertex_merge_distance)
-		merged_winding.append(prev_vtx)
-		for i in range(1, winding.size()):
-			var cur_vtx : Vector3 = winding[i].snappedf(vertex_merge_distance)
+		var merged_vertices : PackedVector3Array = PackedVector3Array()
+		var prev_vtx : Vector3 = vertices[0].snappedf(vertex_merge_distance)
+		merged_vertices.append(prev_vtx)
+		for i in range(1, vertices.size()):
+			var cur_vtx : Vector3 = vertices[i].snappedf(vertex_merge_distance)
 			if prev_vtx != cur_vtx:
-				merged_winding.append(cur_vtx)
+				merged_vertices.append(cur_vtx)
 			prev_vtx = cur_vtx
-		winding = merged_winding
+		vertices = merged_vertices
 	
-	if entity.definition.brush_winding_overrider:
-		var ex: RefCounted = entity.definition.brush_winding_overrider.new()
-		if ex.has_method("_func_godot_modify_vertex_wind"):
-			ex.call("_func_godot_modify_vertex_wind", winding, entity)
+	if entity.definition.modify_vertices_script:
+		var ex: RefCounted = entity.definition.modify_vertices_script.new()
+		if ex.has_method("_func_godot_modify_vertices"):
+			ex.call("_func_godot_modify_vertices", vertices, entity)
 
 
-	return winding
+	return vertices
 
 func generate_brush_vertices(entity_index: int, brush_index: int) -> void:
 	var entity: _EntityData = entity_data[entity_index]

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -61,6 +61,11 @@ var prefix: String = ""
 ## This can be used to programmatically generate class properties when you need it
 @export var entity_extension_script: Script
 
+## Optional script where `_func_godot_modify_vertex_wind` will be called during a build.
+## Provides the Vertices winding as a PackedVector3Array and the entity as a FuncGodotData.EntityData as arguments
+## These can be used to programmatically modify brush vertices during a build.
+@export var brush_winding_overrider : Script
+
 ## Parses the definition and outputs it into the FGD format.
 func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM) -> String:
 	# Class prefix

--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -61,10 +61,10 @@ var prefix: String = ""
 ## This can be used to programmatically generate class properties when you need it
 @export var entity_extension_script: Script
 
-## Optional script where `_func_godot_modify_vertex_wind` will be called during a build.
-## Provides the Vertices winding as a PackedVector3Array and the entity as a FuncGodotData.EntityData as arguments
+## Optional script where `_func_godot_modify_vertices` will be called during a build.
+## Provides the Vertices as a PackedVector3Array and the entity as a FuncGodotData.EntityData as arguments
 ## These can be used to programmatically modify brush vertices during a build.
-@export var brush_winding_overrider : Script
+@export var modify_vertices_script : Script
 
 ## Parses the definition and outputs it into the FGD format.
 func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = FuncGodotFGDFile.FuncGodotTargetMapEditors.TRENCHBROOM) -> String:


### PR DESCRIPTION
This provides an optional script on an entity definition, providing a hook to override the placement of brush vertices during a func_godot build process.

This should be done during the func_godot build process and not on the users side in _func_godot_apply_properties or the build complete, as the new position of these vertices is relevant to setting up any new concave collisions, the UV2 generation(I think?) and the normals(especially relevant when phong shading is set up).

An example of a script that could be used with this allowing a flat brush that has been manually subdivided to have some waviness is as follows:
```
extends RefCounted

var mult := 5.0

func _func_godot_modify_vertex_wind(wind: PackedVector3Array, _entity: FuncGodotData.EntityData) -> void:
	var noisy: FastNoiseLite = load("res://func_godot/classes/func_/func_cave_wall/func_cave_noise.tres")

	for i in wind.size():
		wind[i].z += noisy.get_noise_3d(wind[i].x, wind[i].y, wind[i].z)*mult
```
Some users were already hacking func_godot in the wild to allow for this sort of change(see 0rangeyouglad in showcase-mapping as an example). The entity is also provided so users can get key-value pairs as they are probably relevant if you want to override it using some user-defined params.

I think this is kind of niche change but allows for natural organic terrain to be somewhat more easily done rather than manually changing each vertex in your map editor for when you would rather give up most of your control with it. I think this could also allow users to do automatic subdivisions(I haven't tested that idea out though and would require understanding how the verts are wound up which I don't know how they are done)?

The implementation for this is similar to how I implemented the property attacher stuff. I'm not sure about the names for variables in this change(happy to hear alternatives).