### PR TITLE
Revert build complete optional arguments call (temporarily) 

### DIFF
--- a/addons/func_godot/src/core/entity_assembler.gd
+++ b/addons/func_godot/src/core/entity_assembler.gd
@@ -282,16 +282,7 @@ func apply_entity_properties(node: Node, data: _EntityData) -> void:
 		node.call("_func_godot_apply_properties", properties)
 	
 	if node.has_method("_func_godot_build_complete"):
-		var complete_method : Callable = node.get("_func_godot_build_complete")
-		match complete_method.get_argument_count():
-			0:
-				pass
-			1:
-				# Allow _func_godot_build_complete to optionally have properties passed to it
-				complete_method = complete_method.bind(properties)
-			_:
-				push_error("Entity %s script has a _func_godot_build_complete function with an incorrect number of arguments (expected 0 or 1) - the call may fail" % node.name)
-		complete_method.call_deferred()
+		node.call_deferred("_func_godot_build_complete")
 
 ## Generate a [Node] from [FuncGodotData.EntityData]. The returned node value can be [code]null[/code], 
 ## in the case of [FuncGodotFGDSolidClass] entities with no [FuncGodotData.BrushData] entries.


### PR DESCRIPTION
Reverts func-godot/func_godot_plugin#266 

We're looking at some possible overlap here with the properties resource implementations, so revering this PR (for now)