### PR TITLE
Apply an entity's class properties after its base class'

### DIFF
--- a/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
+++ b/addons/func_godot/src/fgd/func_godot_fgd_entity_class.gd
@@ -246,15 +246,15 @@ func build_def_text(target_editor: FuncGodotFGDFile.FuncGodotTargetMapEditors = 
 	return res
 
 func retrieve_all_class_properties(properties: Dictionary[String, Variant] = {}) -> Dictionary[String, Variant]:
-	for key in class_properties.keys():
-		properties[key] = class_properties[key]
 	for b in base_classes:
 		properties = b.retrieve_all_class_properties(properties)
+	for key in class_properties.keys():
+		properties[key] = class_properties[key]
 	return properties
 
 func retrieve_all_class_property_descriptions(descriptions: Dictionary[String, Variant] = {}) -> Dictionary[String, Variant]:
-	for key in class_property_descriptions.keys():
-		descriptions[key] = class_property_descriptions[key]
 	for b in base_classes:
 		descriptions = b.retrieve_all_class_property_descriptions(descriptions)
+	for key in class_property_descriptions.keys():
+		descriptions[key] = class_property_descriptions[key]
 	return descriptions


### PR DESCRIPTION
This fixes an issue where a child entity class couldn't override the a base class' default value for a property.

Consider the following class hierarchy (in pseudo-code, or whatever you'd call this):

```
parent_entity
  my_property = 0

child_entity extends parent_entity
  my_property = 1
```

In trenchbroom, the default value of `my_property` for a `parent_entity` is shown as `0`, and for a `child_entity` it is shown as `1`. This is what I would expect given the above configuration - the child entity is overriding a default of the parent. But when I build the map in `func_godot`, a child entity will default to `0` instead of `1` due to base class defaults being applied after child class properties.

I'm not really sure if there are further effects from this change, or if there was a particular reason base class defaults were applied over child classes (I haven't checked editors other than trenchbroom, but do other editors handle this case differently?).